### PR TITLE
Fix file watcher ignore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "@mariozechner/pi-coding-agent": "^0.56.3",
         "@sinclair/typebox": "^0.34.48",
+        "@types/picomatch": "^4.0.2",
         "chokidar": "^4.0.0",
         "citty": "^0.2.1",
         "gray-matter": "^4.0.3",
-        "js-yaml": "^4.1.1"
+        "js-yaml": "^4.1.1",
+        "picomatch": "^4.0.3"
       },
       "bin": {
         "busytown": "src/cli.ts"
@@ -2155,6 +2157,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==",
+      "license": "MIT"
+    },
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
@@ -4176,7 +4184,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
   "dependencies": {
     "@mariozechner/pi-coding-agent": "^0.56.3",
     "@sinclair/typebox": "^0.34.48",
+    "@types/picomatch": "^4.0.2",
     "chokidar": "^4.0.0",
     "citty": "^0.2.1",
     "gray-matter": "^4.0.3",
-    "js-yaml": "^4.1.1"
+    "js-yaml": "^4.1.1",
+    "picomatch": "^4.0.3"
   },
   "scripts": {
     "check": "tsc --noEmit",

--- a/src/file-watcher.test.ts
+++ b/src/file-watcher.test.ts
@@ -1,0 +1,20 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { glob, any, DEFAULT_IGNORED } from "./file-watcher.ts";
+
+describe("glob", () => {
+  it("matches a glob pattern", () => {
+    assert(glob("*.ts")("file-watcher.ts"));
+    assert(glob("**/.busytown/**")(".busytown/events.db-wal"));
+  });
+});
+
+describe("any + glob", () => {
+  it("matches any glob pattern", () => {
+    assert(any([glob("*.ts"), glob("**/.busytown/**")])("file-watcher.ts"));
+  });
+
+  it("matches default ignored", () => {
+    assert(any(DEFAULT_IGNORED.map(glob))(".busytown/events.db-wal"));
+  });
+});

--- a/src/file-watcher.ts
+++ b/src/file-watcher.ts
@@ -1,16 +1,28 @@
 import { watch } from "chokidar";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import picomatch from "picomatch";
 import { pushEvent } from "./event-queue.ts";
 
-export type FileWatcherCleanup = () => Promise<void>;
+/**
+ * Returns a predicate that tests whether a path matches the given glob pattern.
+ */
+export const glob = (glob: string) => picomatch(glob);
 
-const DEFAULT_IGNORED = [
+/** Combines predicate functions */
+export const any =
+  (predicates: Array<(path: string) => boolean>) =>
+  (path: string): boolean =>
+    predicates.some((predicate) => predicate(path));
+
+export const DEFAULT_IGNORED = [
   "**/node_modules/**",
   "**/.git/**",
   "**/.busytown/**",
   "**/.DS_Store",
 ];
+
+export type FileWatcherCleanup = () => Promise<void>;
 
 /**
  * Watch the project directory for file changes and push file events.
@@ -25,11 +37,14 @@ const DEFAULT_IGNORED = [
 export const watchFiles = (
   db: DatabaseSync,
   projectRoot: string,
-  ignored: string[] = DEFAULT_IGNORED,
+  ignored = DEFAULT_IGNORED,
 ): FileWatcherCleanup => {
+  // Compile the ignored patterns into a predicate function
+  const isIgnored = any(ignored.map(glob));
+
   const watcher = watch(projectRoot, {
     ignoreInitial: true,
-    ignored,
+    ignored: isIgnored,
     awaitWriteFinish: { stabilityThreshold: 300 },
   });
 


### PR DESCRIPTION
Chokidar doesn't support glob since v4. Bring in picomatch to fix that.