### PR TITLE
Show live agent output progress in dashboard widget

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -237,6 +237,7 @@ export const startNotifier = (
     lastSeenId = events[events.length - 1]!.id;
 
     for (const event of events) {
+      if (event.type.endsWith(".progress")) continue;
       const payload = JSON.stringify(event.payload);
       ctx.ui.notify(`> ${event.type}\t@${event.agent_id}\t${payload}`, "info");
     }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -67,7 +67,12 @@ const applyAgentEvent = (
     return { ...agent, progressChars: chars };
   }
   if (action === "finish") {
-    return { ...agent, status: "idle", eventType: undefined, progressChars: undefined };
+    return {
+      ...agent,
+      status: "idle",
+      eventType: undefined,
+      progressChars: undefined,
+    };
   }
   if (action === "error") {
     return { ...agent, status: "error", progressChars: undefined };
@@ -131,9 +136,10 @@ const buildWidgetLines = (state: DashboardState, theme: Theme): string[] => {
     const name = theme.fg("text", agent.id);
     if (agent.status === "running") {
       const icon = theme.fg("accent", "●");
-      const progress = agent.progressChars != null
-        ? ` ${theme.fg("dim", formatChars(agent.progressChars))}`
-        : "";
+      const progress =
+        agent.progressChars != null
+          ? ` ${theme.fg("dim", formatChars(agent.progressChars))}`
+          : "";
       const detail = agent.eventType
         ? theme.fg("muted", `(${agent.eventType})`)
         : theme.fg("muted", "(running)");

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -26,6 +26,7 @@ type AgentState = {
   id: string;
   status: "idle" | "running" | "error";
   eventType?: string;
+  progressChars?: number;
 };
 
 type DashboardState = {
@@ -42,7 +43,7 @@ type DashboardAction =
 // Event helpers
 // ---------------------------------------------------------------------------
 
-const AGENT_EVENT_RE = /^sys\.agent\.(.+)\.(start|finish|error)$/;
+const AGENT_EVENT_RE = /^sys\.agent\.(.+)\.(start|finish|error|progress)$/;
 
 const applyAgentEvent = (
   agent: AgentState,
@@ -56,13 +57,20 @@ const applyAgentEvent = (
       eventType: (payload as Record<string, unknown>)?.event_type as
         | string
         | undefined,
+      progressChars: undefined,
     };
   }
+  if (action === "progress") {
+    const chars = (payload as Record<string, unknown>)?.chars as
+      | number
+      | undefined;
+    return { ...agent, progressChars: chars };
+  }
   if (action === "finish") {
-    return { ...agent, status: "idle", eventType: undefined };
+    return { ...agent, status: "idle", eventType: undefined, progressChars: undefined };
   }
   if (action === "error") {
-    return { ...agent, status: "error" };
+    return { ...agent, status: "error", progressChars: undefined };
   }
   return agent;
 };
@@ -123,10 +131,13 @@ const buildWidgetLines = (state: DashboardState, theme: Theme): string[] => {
     const name = theme.fg("text", agent.id);
     if (agent.status === "running") {
       const icon = theme.fg("accent", "●");
+      const progress = agent.progressChars != null
+        ? ` ${theme.fg("dim", formatChars(agent.progressChars))}`
+        : "";
       const detail = agent.eventType
         ? theme.fg("muted", `(${agent.eventType})`)
         : theme.fg("muted", "(running)");
-      parts.push(`${icon} ${name} ${detail}`);
+      parts.push(`${icon} ${name} ${detail}${progress}`);
     } else if (agent.status === "error") {
       parts.push(
         `${theme.fg("error", "●")} ${name} ${theme.fg("error", "(error)")}`,
@@ -445,6 +456,12 @@ export const registerEventLogCommand = (
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+const formatChars = (chars: number): string => {
+  if (chars < 1000) return `${chars}B`;
+  if (chars < 1_000_000) return `${(chars / 1000).toFixed(1)}kB`;
+  return `${(chars / 1_000_000).toFixed(1)}MB`;
+};
 
 type FgColor = Parameters<Theme["fg"]>[0];
 

--- a/src/pi-process.ts
+++ b/src/pi-process.ts
@@ -20,18 +20,40 @@ import { logger } from "./lib/json-logger.ts";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const agentExtensionPath = path.join(__dirname, "agent-extension.ts");
 
-const pipeLinesToEvents = (
+const MAX_OUTPUT_CHARS = 100_000;
+
+/** Buffer child process output lines in memory. Returns the mutable array. */
+const collectOutput = (
   child: ChildProcess,
   stream: "stdout" | "stderr",
+): string[] => {
+  const lines: string[] = [];
+  const readable = child[stream];
+  if (!readable) return lines;
+  const rl = createInterface({ input: readable });
+  rl.on("line", (line) => {
+    lines.push(line);
+  });
+  return lines;
+};
+
+/** Push buffered output as a single summary event. */
+const pushOutputEvent = (
   db: DatabaseSync,
   agentId: string,
   eventType: string,
+  lines: string[],
 ): void => {
-  const readable = child[stream];
-  if (!readable) return;
-  const rl = createInterface({ input: readable });
-  rl.on("line", (line) => {
-    pushEvent(db, agentId, eventType, { line });
+  if (lines.length === 0) return;
+  let text = lines.join("\n");
+  const truncated = text.length > MAX_OUTPUT_CHARS;
+  if (truncated) {
+    text = text.slice(0, MAX_OUTPUT_CHARS);
+  }
+  pushEvent(db, agentId, eventType, {
+    line_count: lines.length,
+    truncated,
+    text,
   });
 };
 
@@ -89,20 +111,8 @@ export const runPiAgent = ({
     };
     abortSignal?.addEventListener("abort", onAbort, { once: true });
 
-    pipeLinesToEvents(
-      child,
-      "stdout",
-      db,
-      agent.id,
-      `sys.agent.${agent.id}.stdout`,
-    );
-    pipeLinesToEvents(
-      child,
-      "stderr",
-      db,
-      agent.id,
-      `sys.agent.${agent.id}.stderr`,
-    );
+    const stdoutLines = collectOutput(child, "stdout");
+    const stderrLines = collectOutput(child, "stderr");
 
     // Write event JSON as the task prompt on stdin
     child.stdin?.write(JSON.stringify(event));
@@ -118,6 +128,8 @@ export const runPiAgent = ({
     });
     child.on("close", (code) => {
       abortSignal?.removeEventListener("abort", onAbort);
+      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stdout`, stdoutLines);
+      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stderr`, stderrLines);
       const exitCode = code ?? 1;
       if (exitCode !== 0) {
         logger.warn("Pi agent exited with non-zero code", {
@@ -165,20 +177,8 @@ export const runShellAgent = ({
     };
     abortSignal?.addEventListener("abort", onAbort, { once: true });
 
-    pipeLinesToEvents(
-      child,
-      "stdout",
-      db,
-      agent.id,
-      `sys.agent.${agent.id}.stdout`,
-    );
-    pipeLinesToEvents(
-      child,
-      "stderr",
-      db,
-      agent.id,
-      `sys.agent.${agent.id}.stderr`,
-    );
+    const stdoutLines = collectOutput(child, "stdout");
+    const stderrLines = collectOutput(child, "stderr");
 
     child.on("error", (err) => {
       logger.error("Shell agent failed to spawn", {
@@ -190,6 +190,8 @@ export const runShellAgent = ({
     });
     child.on("close", (code) => {
       abortSignal?.removeEventListener("abort", onAbort);
+      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stdout`, stdoutLines);
+      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stderr`, stderrLines);
       const exitCode = code ?? 1;
       if (exitCode !== 0) {
         logger.warn("Shell agent exited with non-zero code", {
@@ -289,20 +291,8 @@ export const runClaudeAgent = ({
     };
     abortSignal?.addEventListener("abort", onAbort, { once: true });
 
-    pipeLinesToEvents(
-      child,
-      "stdout",
-      db,
-      agent.id,
-      `sys.agent.${agent.id}.stdout`,
-    );
-    pipeLinesToEvents(
-      child,
-      "stderr",
-      db,
-      agent.id,
-      `sys.agent.${agent.id}.stderr`,
-    );
+    const stdoutLines = collectOutput(child, "stdout");
+    const stderrLines = collectOutput(child, "stderr");
 
     // Write event JSON as the user prompt on stdin
     child.stdin?.write(JSON.stringify(event));
@@ -318,6 +308,8 @@ export const runClaudeAgent = ({
     });
     child.on("close", (code) => {
       abortSignal?.removeEventListener("abort", onAbort);
+      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stdout`, stdoutLines);
+      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stderr`, stderrLines);
       const exitCode = code ?? 1;
       if (exitCode !== 0) {
         logger.warn("Claude agent exited with non-zero code", {

--- a/src/pi-process.ts
+++ b/src/pi-process.ts
@@ -48,8 +48,9 @@ const startProgressReporter = (
 ): (() => void) => {
   let prevChars = 0;
   const interval = setInterval(() => {
-    const chars = stdoutLines.reduce((n, l) => n + l.length, 0)
-      + stderrLines.reduce((n, l) => n + l.length, 0);
+    const chars =
+      stdoutLines.reduce((n, l) => n + l.length, 0) +
+      stderrLines.reduce((n, l) => n + l.length, 0);
     if (chars === prevChars) return;
     prevChars = chars;
     pushEvent(db, agentId, `sys.agent.${agentId}.progress`, {
@@ -136,7 +137,12 @@ export const runPiAgent = ({
 
     const stdoutLines = collectOutput(child, "stdout");
     const stderrLines = collectOutput(child, "stderr");
-    const stopProgress = startProgressReporter(db, agent.id, stdoutLines, stderrLines);
+    const stopProgress = startProgressReporter(
+      db,
+      agent.id,
+      stdoutLines,
+      stderrLines,
+    );
 
     // Write event JSON as the task prompt on stdin
     child.stdin?.write(JSON.stringify(event));
@@ -154,8 +160,18 @@ export const runPiAgent = ({
     child.on("close", (code) => {
       stopProgress();
       abortSignal?.removeEventListener("abort", onAbort);
-      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stdout`, stdoutLines);
-      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stderr`, stderrLines);
+      pushOutputEvent(
+        db,
+        agent.id,
+        `sys.agent.${agent.id}.stdout`,
+        stdoutLines,
+      );
+      pushOutputEvent(
+        db,
+        agent.id,
+        `sys.agent.${agent.id}.stderr`,
+        stderrLines,
+      );
       const exitCode = code ?? 1;
       if (exitCode !== 0) {
         logger.warn("Pi agent exited with non-zero code", {
@@ -205,7 +221,12 @@ export const runShellAgent = ({
 
     const stdoutLines = collectOutput(child, "stdout");
     const stderrLines = collectOutput(child, "stderr");
-    const stopProgress = startProgressReporter(db, agent.id, stdoutLines, stderrLines);
+    const stopProgress = startProgressReporter(
+      db,
+      agent.id,
+      stdoutLines,
+      stderrLines,
+    );
 
     child.on("error", (err) => {
       stopProgress();
@@ -219,8 +240,18 @@ export const runShellAgent = ({
     child.on("close", (code) => {
       stopProgress();
       abortSignal?.removeEventListener("abort", onAbort);
-      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stdout`, stdoutLines);
-      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stderr`, stderrLines);
+      pushOutputEvent(
+        db,
+        agent.id,
+        `sys.agent.${agent.id}.stdout`,
+        stdoutLines,
+      );
+      pushOutputEvent(
+        db,
+        agent.id,
+        `sys.agent.${agent.id}.stderr`,
+        stderrLines,
+      );
       const exitCode = code ?? 1;
       if (exitCode !== 0) {
         logger.warn("Shell agent exited with non-zero code", {
@@ -322,7 +353,12 @@ export const runClaudeAgent = ({
 
     const stdoutLines = collectOutput(child, "stdout");
     const stderrLines = collectOutput(child, "stderr");
-    const stopProgress = startProgressReporter(db, agent.id, stdoutLines, stderrLines);
+    const stopProgress = startProgressReporter(
+      db,
+      agent.id,
+      stdoutLines,
+      stderrLines,
+    );
 
     // Write event JSON as the user prompt on stdin
     child.stdin?.write(JSON.stringify(event));
@@ -340,8 +376,18 @@ export const runClaudeAgent = ({
     child.on("close", (code) => {
       stopProgress();
       abortSignal?.removeEventListener("abort", onAbort);
-      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stdout`, stdoutLines);
-      pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stderr`, stderrLines);
+      pushOutputEvent(
+        db,
+        agent.id,
+        `sys.agent.${agent.id}.stdout`,
+        stdoutLines,
+      );
+      pushOutputEvent(
+        db,
+        agent.id,
+        `sys.agent.${agent.id}.stderr`,
+        stderrLines,
+      );
       const exitCode = code ?? 1;
       if (exitCode !== 0) {
         logger.warn("Claude agent exited with non-zero code", {

--- a/src/pi-process.ts
+++ b/src/pi-process.ts
@@ -37,6 +37,29 @@ const collectOutput = (
   return lines;
 };
 
+const PROGRESS_INTERVAL_MS = 2000;
+
+/** Push periodic progress events while a child process is running. */
+const startProgressReporter = (
+  db: DatabaseSync,
+  agentId: string,
+  stdoutLines: string[],
+  stderrLines: string[],
+): (() => void) => {
+  let prevChars = 0;
+  const interval = setInterval(() => {
+    const chars = stdoutLines.reduce((n, l) => n + l.length, 0)
+      + stderrLines.reduce((n, l) => n + l.length, 0);
+    if (chars === prevChars) return;
+    prevChars = chars;
+    pushEvent(db, agentId, `sys.agent.${agentId}.progress`, {
+      chars,
+      lines: stdoutLines.length + stderrLines.length,
+    });
+  }, PROGRESS_INTERVAL_MS);
+  return () => clearInterval(interval);
+};
+
 /** Push buffered output as a single summary event. */
 const pushOutputEvent = (
   db: DatabaseSync,
@@ -113,12 +136,14 @@ export const runPiAgent = ({
 
     const stdoutLines = collectOutput(child, "stdout");
     const stderrLines = collectOutput(child, "stderr");
+    const stopProgress = startProgressReporter(db, agent.id, stdoutLines, stderrLines);
 
     // Write event JSON as the task prompt on stdin
     child.stdin?.write(JSON.stringify(event));
     child.stdin?.end();
 
     child.on("error", (err) => {
+      stopProgress();
       logger.error("Pi agent failed to spawn", {
         agent: agent.id,
         event_id: event.id,
@@ -127,6 +152,7 @@ export const runPiAgent = ({
       reject(err);
     });
     child.on("close", (code) => {
+      stopProgress();
       abortSignal?.removeEventListener("abort", onAbort);
       pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stdout`, stdoutLines);
       pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stderr`, stderrLines);
@@ -179,8 +205,10 @@ export const runShellAgent = ({
 
     const stdoutLines = collectOutput(child, "stdout");
     const stderrLines = collectOutput(child, "stderr");
+    const stopProgress = startProgressReporter(db, agent.id, stdoutLines, stderrLines);
 
     child.on("error", (err) => {
+      stopProgress();
       logger.error("Shell agent failed to spawn", {
         agent: agent.id,
         event_id: event.id,
@@ -189,6 +217,7 @@ export const runShellAgent = ({
       reject(err);
     });
     child.on("close", (code) => {
+      stopProgress();
       abortSignal?.removeEventListener("abort", onAbort);
       pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stdout`, stdoutLines);
       pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stderr`, stderrLines);
@@ -293,12 +322,14 @@ export const runClaudeAgent = ({
 
     const stdoutLines = collectOutput(child, "stdout");
     const stderrLines = collectOutput(child, "stderr");
+    const stopProgress = startProgressReporter(db, agent.id, stdoutLines, stderrLines);
 
     // Write event JSON as the user prompt on stdin
     child.stdin?.write(JSON.stringify(event));
     child.stdin?.end();
 
     child.on("error", (err) => {
+      stopProgress();
       logger.error("Claude agent failed to spawn", {
         agent: agent.id,
         event_id: event.id,
@@ -307,6 +338,7 @@ export const runClaudeAgent = ({
       reject(err);
     });
     child.on("close", (code) => {
+      stopProgress();
       abortSignal?.removeEventListener("abort", onAbort);
       pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stdout`, stdoutLines);
       pushOutputEvent(db, agent.id, `sys.agent.${agent.id}.stderr`, stderrLines);


### PR DESCRIPTION
## Summary

<img width="1470" height="167" alt="image" src="https://github.com/user-attachments/assets/82be0031-9633-430f-aba1-4928617b3277" />

Closes #35. Adds live output progress to the dashboard widget while agents are running.

Every 2s, a lightweight `sys.agent.<id>.progress` event is pushed with the current `{ chars, lines }` count from the output buffer. The dashboard widget picks this up and displays it:

```
● doc-scanner (scan.request) 12.4kB
```

- Only emits when the count has changed (no noise from idle agents)
- Progress is cleared on start/finish/error transitions
- Applies to all three agent types (Pi, Shell, Claude)
- Builds on #34 (buffered output)

## Test plan

- [x] All 165 existing tests pass
- [x] Run daemon with an agent — verify progress updates appear in the widget every ~2s
- [x] Verify progress clears when agent finishes
- [x] Verify no progress events when agent is idle
- [x] Check `/busytown-console` shows progress events

🤖 Generated with [Claude Code](https://claude.com/claude-code)