### PR TITLE
Fix model names in ralph agents

### DIFF
--- a/examples/ralph/agents/code.md
+++ b/examples/ralph/agents/code.md
@@ -1,6 +1,6 @@
 ---
 description: Implements code changes by following plans written by the plan agent
-model: "sonnet"
+model: "claude-sonnet-4-6"
 listen:
   - "plan.created"
 emits:

--- a/examples/ralph/agents/plan.md
+++ b/examples/ralph/agents/plan.md
@@ -1,6 +1,6 @@
 ---
 description: Explores the codebase and writes implementation plans as markdown files
-model: "opus"
+model: "claude-opus-4-6"
 listen:
   - "plan.request"
   - "review.created"

--- a/examples/ralph/agents/review.md
+++ b/examples/ralph/agents/review.md
@@ -1,6 +1,6 @@
 ---
 description: Reviews code changes for correctness, type safety, and style
-model: "opus"
+model: "claude-opus-4-6"
 listen:
   - "code.review"
 emits:


### PR DESCRIPTION
bare names are getting matched with Amazon Bedrock provider in latest Pi. We need to be more specific.