### PR TITLE
Simplify agent type to use handle() vs stream()

### DIFF
--- a/src/agent-system.test.ts
+++ b/src/agent-system.test.ts
@@ -9,13 +9,17 @@ const createTestDb = () => openDb(":memory:");
 const wait = (ms = 100) => new Promise((r) => setTimeout(r, ms));
 
 describe("agentSystemOf", () => {
-  describe("registerAgent", () => {
-    it("registers agent and returns its id", async () => {
+  describe("spawnAgent", () => {
+    it("spawns agent and returns its id", async () => {
       const db = createTestDb();
       const system = agentSystemOf(db, 10);
-      const agent = mockAgentOf({ id: "a1" });
+      const mock = mockAgentOf();
 
-      const id = system.registerAgent(agent);
+      const id = await system.spawnAgent({
+        id: "a1",
+        listen: ["*"],
+        setup: mock.setup,
+      });
 
       assert.equal(id, "a1");
       await asyncDispose(system);
@@ -25,11 +29,14 @@ describe("agentSystemOf", () => {
     it("throws on duplicate agent id", async () => {
       const db = createTestDb();
       const system = agentSystemOf(db, 10);
-      const a1 = mockAgentOf({ id: "dup" });
-      const a2 = mockAgentOf({ id: "dup" });
+      const m1 = mockAgentOf();
+      const m2 = mockAgentOf();
 
-      system.registerAgent(a1);
-      assert.throws(() => system.registerAgent(a2), /already registered/);
+      await system.spawnAgent({ id: "dup", listen: ["*"], setup: m1.setup });
+      await assert.rejects(
+        () => system.spawnAgent({ id: "dup", listen: ["*"], setup: m2.setup }),
+        /already registered/,
+      );
 
       await asyncDispose(system);
       db.close();
@@ -40,8 +47,10 @@ describe("agentSystemOf", () => {
       const system = agentSystemOf(db, 10);
       await asyncDispose(system);
 
-      const agent = mockAgentOf({ id: "late" });
-      assert.throws(() => system.registerAgent(agent));
+      const mock = mockAgentOf();
+      await assert.rejects(() =>
+        system.spawnAgent({ id: "late", listen: ["*"], setup: mock.setup }),
+      );
 
       db.close();
     });
@@ -51,9 +60,13 @@ describe("agentSystemOf", () => {
     it("agent processes matching events", async () => {
       const db = createTestDb();
       const system = agentSystemOf(db, 10);
-      const agent = mockAgentOf({ id: "proc", listen: ["task.*"] });
+      const mock = mockAgentOf();
 
-      system.registerAgent(agent);
+      await system.spawnAgent({
+        id: "proc",
+        listen: ["task.*"],
+        setup: mock.setup,
+      });
       pushEvent(db, "external", "task.created", { name: "test" });
       pushEvent(db, "external", "other.event");
       pushEvent(db, "external", "task.updated", { name: "test2" });
@@ -61,18 +74,23 @@ describe("agentSystemOf", () => {
       await wait();
       await asyncDispose(system);
 
-      assert.equal(agent.received.length, 2);
-      assert.equal(agent.received[0].type, "task.created");
-      assert.equal(agent.received[1].type, "task.updated");
+      assert.equal(mock.received.length, 2);
+      assert.equal(mock.received[0].type, "task.created");
+      assert.equal(mock.received[1].type, "task.updated");
       db.close();
     });
 
     it("agent ignores own events when ignoreSelf is true", async () => {
       const db = createTestDb();
       const system = agentSystemOf(db, 10);
-      const agent = mockAgentOf({ id: "self-ignore", ignoreSelf: true });
+      const mock = mockAgentOf();
 
-      system.registerAgent(agent);
+      await system.spawnAgent({
+        id: "self-ignore",
+        listen: ["*"],
+        ignoreSelf: true,
+        setup: mock.setup,
+      });
       pushEvent(db, "self-ignore", "task.created");
       pushEvent(db, "other", "task.created");
 
@@ -80,44 +98,49 @@ describe("agentSystemOf", () => {
       await asyncDispose(system);
 
       assert.ok(
-        agent.received.every((e) => e.agent_id !== "self-ignore"),
+        mock.received.every((e) => e.agent_id !== "self-ignore"),
         "Should not process own events",
       );
-      assert.equal(agent.received.length, 1);
+      assert.equal(mock.received.length, 1);
       db.close();
     });
 
     it("agent processes own events when ignoreSelf is false", async () => {
       const db = createTestDb();
       const system = agentSystemOf(db, 10);
-      const agent = mockAgentOf({ id: "self-proc", ignoreSelf: false });
+      const mock = mockAgentOf();
 
-      system.registerAgent(agent);
+      await system.spawnAgent({
+        id: "self-proc",
+        listen: ["*"],
+        ignoreSelf: false,
+        setup: mock.setup,
+      });
       pushEvent(db, "self-proc", "hello");
 
       await wait();
       await asyncDispose(system);
 
       assert.ok(
-        agent.received.some((e) => e.agent_id === "self-proc"),
+        mock.received.some((e) => e.agent_id === "self-proc"),
         "Should process own events",
       );
       db.close();
     });
 
-    it("emits response drafts back into the queue", async () => {
+    it("emits response events back into the queue via send", async () => {
       const db = createTestDb();
       const system = agentSystemOf(db, 10);
-      const agent = mockAgentOf({
-        id: "emitter",
-        listen: ["request"],
-        onEvent: () => [
-          { type: "response.text", payload: { text: "hello" } },
-          { type: "response.done", payload: {} },
-        ],
+      const mock = mockAgentOf(async (send) => {
+        await send("response.text", { text: "hello" });
+        await send("response.done", {});
       });
 
-      system.registerAgent(agent);
+      await system.spawnAgent({
+        id: "emitter",
+        listen: ["request"],
+        setup: mock.setup,
+      });
       pushEvent(db, "external", "request");
 
       await wait();
@@ -135,22 +158,24 @@ describe("agentSystemOf", () => {
   });
 
   describe("disposeAgent", () => {
-    it("disposes a registered agent by id", async () => {
+    it("disposes a spawned agent by id", async () => {
       const db = createTestDb();
       const system = agentSystemOf(db, 10);
-      const agent = mockAgentOf({ id: "killable" });
+      const mock = mockAgentOf();
 
-      system.registerAgent(agent);
+      await system.spawnAgent({
+        id: "killable",
+        listen: ["*"],
+        setup: mock.setup,
+      });
       await system.disposeAgent("killable");
-
-      assert.ok(agent.disposed.aborted, "Agent should be disposed");
 
       // Events pushed after disposal should not be processed
       pushEvent(db, "other", "after-kill");
       await wait(50);
 
       assert.ok(
-        !agent.received.some((e) => e.type === "after-kill"),
+        !mock.received.some((e) => e.type === "after-kill"),
         "Should not process events after disposal",
       );
 
@@ -168,39 +193,32 @@ describe("agentSystemOf", () => {
       await asyncDispose(system);
       db.close();
     });
-
-    it("agent unregisters itself on disposal", async () => {
-      const db = createTestDb();
-      const system = agentSystemOf(db, 10);
-      const agent = mockAgentOf({ id: "unreg" });
-
-      system.registerAgent(agent);
-      await asyncDispose(agent);
-      await wait(50);
-
-      // Re-registering with same id should work since old one unregistered
-      const agent2 = mockAgentOf({ id: "unreg" });
-      system.registerAgent(agent2);
-
-      await asyncDispose(system);
-      db.close();
-    });
   });
 
   describe("system disposal", () => {
     it("disposing system stops all agents", async () => {
       const db = createTestDb();
       const system = agentSystemOf(db, 10);
-      const a1 = mockAgentOf({ id: "a1" });
-      const a2 = mockAgentOf({ id: "a2" });
+      const m1 = mockAgentOf();
+      const m2 = mockAgentOf();
 
-      system.registerAgent(a1);
-      system.registerAgent(a2);
+      await system.spawnAgent({ id: "a1", listen: ["*"], setup: m1.setup });
+      await system.spawnAgent({ id: "a2", listen: ["*"], setup: m2.setup });
 
       await asyncDispose(system);
 
-      assert.ok(a1.disposed.aborted, "Agent a1 should be disposed");
-      assert.ok(a2.disposed.aborted, "Agent a2 should be disposed");
+      // After system disposal, no events should be processed
+      pushEvent(db, "other", "after-dispose");
+      await wait(50);
+
+      assert.ok(
+        !m1.received.some((e) => e.type === "after-dispose"),
+        "Agent a1 should not process events after system disposal",
+      );
+      assert.ok(
+        !m2.received.some((e) => e.type === "after-dispose"),
+        "Agent a2 should not process events after system disposal",
+      );
       db.close();
     });
 

--- a/src/agent-system.test.ts
+++ b/src/agent-system.test.ts
@@ -1,12 +1,76 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { openDb, pushEvent, getEventsSince } from "./event-queue.ts";
-import { agentSystemOf } from "./agent-system.ts";
+import { agentSystemOf, shouldHandleEventOf } from "./agent-system.ts";
+import { type Event } from "./lib/event.ts";
 import { mockAgentOf } from "./mock-agent.ts";
 import { asyncDispose } from "./lib/dispose.ts";
 
+const eventOf = (type: string, agent_id: string): Event => ({
+  id: 1,
+  timestamp: Date.now(),
+  type,
+  agent_id,
+  payload: {},
+});
+
 const createTestDb = () => openDb(":memory:");
 const wait = (ms = 100) => new Promise((r) => setTimeout(r, ms));
+
+describe("shouldHandleEventOf", () => {
+  it("matches exact event type", () => {
+    const shouldHandle = shouldHandleEventOf("agent-a", false, ["task.start"]);
+    assert.equal(shouldHandle(eventOf("task.start", "agent-b")), true);
+  });
+
+  it("rejects non-matching event type", () => {
+    const shouldHandle = shouldHandleEventOf("agent-a", false, ["task.start"]);
+    assert.equal(shouldHandle(eventOf("task.end", "agent-b")), false);
+  });
+
+  it("matches wildcard pattern", () => {
+    const shouldHandle = shouldHandleEventOf("agent-a", false, ["*"]);
+    assert.equal(shouldHandle(eventOf("anything", "agent-b")), true);
+  });
+
+  it("matches prefix pattern", () => {
+    const shouldHandle = shouldHandleEventOf("agent-a", false, ["task.*"]);
+    assert.equal(shouldHandle(eventOf("task.start", "agent-b")), true);
+    assert.equal(shouldHandle(eventOf("task.end", "agent-b")), true);
+    assert.equal(shouldHandle(eventOf("agent.ready", "agent-b")), false);
+  });
+
+  it("ignores self events when ignoreSelf is true", () => {
+    const shouldHandle = shouldHandleEventOf("agent-a", true, ["*"]);
+    assert.equal(shouldHandle(eventOf("task.start", "agent-a")), false);
+  });
+
+  it("does not ignore self events when ignoreSelf is false", () => {
+    const shouldHandle = shouldHandleEventOf("agent-a", false, ["*"]);
+    assert.equal(shouldHandle(eventOf("task.start", "agent-a")), true);
+  });
+
+  it("ignores self but handles events from other agents", () => {
+    const shouldHandle = shouldHandleEventOf("agent-a", true, ["task.*"]);
+    assert.equal(shouldHandle(eventOf("task.start", "agent-a")), false);
+    assert.equal(shouldHandle(eventOf("task.start", "agent-b")), true);
+  });
+
+  it("returns false when listen list is empty", () => {
+    const shouldHandle = shouldHandleEventOf("agent-a", false, []);
+    assert.equal(shouldHandle(eventOf("task.start", "agent-b")), false);
+  });
+
+  it("matches any of multiple listen patterns", () => {
+    const shouldHandle = shouldHandleEventOf("agent-a", false, [
+      "task.start",
+      "agent.ready",
+    ]);
+    assert.equal(shouldHandle(eventOf("task.start", "agent-b")), true);
+    assert.equal(shouldHandle(eventOf("agent.ready", "agent-b")), true);
+    assert.equal(shouldHandle(eventOf("task.end", "agent-b")), false);
+  });
+});
 
 describe("agentSystemOf", () => {
   describe("spawnAgent", () => {

--- a/src/agent-system.ts
+++ b/src/agent-system.ts
@@ -37,12 +37,12 @@ type SpawnedAgent = {
 /** Create a predicate function that checks if agent should handle event. */
 export const shouldHandleEventOf =
   (id: string, ignoreSelf: boolean, listen: string[]) =>
-    (event: Event): boolean => {
-      if (ignoreSelf && event.agent_id === id) {
-        return false;
-      }
-      return eventMatches(event, listen);
-    };
+  (event: Event): boolean => {
+    if (ignoreSelf && event.agent_id === id) {
+      return false;
+    }
+    return eventMatches(event, listen);
+  };
 
 export const agentSystemOf = (
   db: DatabaseSync,

--- a/src/agent-system.ts
+++ b/src/agent-system.ts
@@ -2,9 +2,9 @@ import type { DatabaseSync } from "node:sqlite";
 import { eventMatches, type Event } from "./lib/event.ts";
 import { pullNextMatchingEvent, pushEvent } from "./event-queue.ts";
 import { abortableSleep } from "./lib/promise.ts";
-import { asyncDispose } from "./lib/dispose.ts";
 import { loggerOf } from "./lib/json-logger.ts";
-import { type Agent } from "./agent.ts";
+import { type Agent, type AgentSetup, type SendFn } from "./agent.ts";
+import { parseSlug } from "./lib/slug.ts";
 
 const logger = loggerOf({ source: "agent-system.ts" });
 
@@ -12,11 +12,26 @@ export type SystemStats = {
   agents: string[];
 };
 
+export type SpawnAgentConfig = {
+  id: string;
+  listen: string[];
+  ignoreSelf?: boolean;
+  setup: AgentSetup;
+};
+
 export type AgentSystem = {
-  registerAgent: (agent: Agent) => string;
-  disposeAgent: (id: string) => Promise<void>;
-  stats: () => SystemStats;
+  spawnAgent(config: SpawnAgentConfig): Promise<string>;
+  disposeAgent(id: string): Promise<void>;
+  stats(): SystemStats;
   [Symbol.asyncDispose](): Promise<void>;
+};
+
+type SpawnedAgent = {
+  id: string;
+  listen: string[];
+  ignoreSelf: boolean;
+  agent: Agent;
+  abortController: AbortController;
 };
 
 export const agentSystemOf = (
@@ -25,97 +40,106 @@ export const agentSystemOf = (
 ): AgentSystem => {
   logger.debug("Agent system created");
   const systemAbortController = new AbortController();
-  // Registry of agents
-  const agents: Map<string, Agent> = new Map();
 
-  const stats = (): SystemStats => {
-    return {
-      agents: Array.from(agents.keys()),
-    };
-  };
+  // Registry of spawned agents
+  const agents: Map<string, SpawnedAgent> = new Map();
 
-  const forkAgentPollLoop = async (agent: Agent): Promise<void> => {
-    // If either the agent or the system is disposed, abort the loop
+  const stats = (): SystemStats => ({
+    agents: Array.from(agents.keys()),
+  });
+
+  const forkAgentPollLoop = async (entry: SpawnedAgent): Promise<void> => {
+    const { id, listen, ignoreSelf, agent, abortController } = entry;
+
     const signal = AbortSignal.any([
-      agent.disposed,
+      abortController.signal,
       systemAbortController.signal,
     ]);
 
     const shouldHandleEvent = (event: Event) => {
-      if (agent.ignoreSelf && event.agent_id === agent.id) {
+      if (ignoreSelf !== false && event.agent_id === id) {
         return false;
       }
-      return eventMatches(event, agent.listen);
+      return eventMatches(event, listen);
     };
 
     try {
       while (!signal.aborted) {
-        const event = pullNextMatchingEvent(db, agent.id, shouldHandleEvent);
+        const event = pullNextMatchingEvent(db, id, shouldHandleEvent);
 
         if (!event) {
           await abortableSleep(timeout, signal);
           continue;
         }
 
-        for await (const draft of agent.stream(event)) {
-          // Break the stream if either agent or system aborted.
-          // This will run ReadableStream.cancel() and clean up resources.
-          if (signal.aborted) {
-            break;
-          }
-          pushEvent(db, agent.id, draft.type, draft.payload);
-        }
+        if (signal.aborted) break;
+
+        await agent.handle(event, { signal });
       }
     } catch (e) {
-      logger.warn("Agent poll loop error", { error: `${e}` });
-    } finally {
-      await asyncDispose(agent);
+      if (!signal.aborted) {
+        logger.warn("Agent poll loop error", { agent_id: id, error: `${e}` });
+      }
     }
   };
 
-  const registerAgent = (agent: Agent): string => {
+  const spawnAgent = async (config: SpawnAgentConfig): Promise<string> => {
     systemAbortController.signal.throwIfAborted();
-    agent.disposed.throwIfAborted();
+    const { ignoreSelf = true, listen, setup } = config;
+    // Make sure ID is valid slug
+    const id = parseSlug(config.id);
 
-    if (agents.has(agent.id)) {
-      throw new Error(`Agent with id ${agent.id} already registered`);
+    if (agents.has(id)) {
+      throw new Error(`Agent with id ${id} already registered`);
     }
 
-    logger.debug("Register agent", { id: agent.id });
+    logger.debug("Spawning agent", { id });
 
-    // Automatically unregister agent if killed
-    agent.disposed.addEventListener(
-      "abort",
-      () => {
-        agents.delete(agent.id);
-      },
-      { once: true },
-    );
+    const send: SendFn = async (type, payload) => {
+      pushEvent(db, id, type, payload);
+    };
 
-    forkAgentPollLoop(agent);
+    try {
+      const agent = await setup(id, send);
+      const abortController = new AbortController();
 
-    agents.set(agent.id, agent);
+      const entry: SpawnedAgent = {
+        id,
+        listen,
+        ignoreSelf,
+        agent,
+        abortController,
+      };
 
-    return agent.id;
+      agents.set(id, entry);
+      forkAgentPollLoop(entry);
+
+      return config.id;
+    } catch (e) {
+      logger.error("Error spawning agent", {
+        id,
+        error: `${e}`,
+      });
+      throw e;
+    }
   };
 
   const disposeAgent = async (id: string): Promise<void> => {
     logger.debug("Disposing agent", { id });
-    const agent = agents.get(id);
-    if (!agent) {
-      return;
-    }
-    // Clean up and automatically unregister via abort event
-    await asyncDispose(agent);
+    const entry = agents.get(id);
+    if (!entry) return;
+
+    entry.abortController.abort(new Error("Agent disposed"));
+    agents.delete(id);
+    await entry.agent[Symbol.asyncDispose]();
     logger.debug("Disposed agent", { id });
   };
 
   const disposeSystem = async (): Promise<void> => {
     logger.debug("Disposing agent system");
-    if (systemAbortController.signal.aborted) {
-      return;
-    }
+    if (systemAbortController.signal.aborted) return;
     systemAbortController.abort(new Error("System stopped"));
+
     const kills = Array.from(agents.keys()).map(disposeAgent);
     await Promise.allSettled(kills);
     agents.clear();
@@ -123,7 +147,7 @@ export const agentSystemOf = (
   };
 
   return {
-    registerAgent,
+    spawnAgent,
     disposeAgent,
     stats,
     [Symbol.asyncDispose]: disposeSystem,

--- a/src/agent-system.ts
+++ b/src/agent-system.ts
@@ -37,12 +37,12 @@ type SpawnedAgent = {
 /** Create a predicate function that checks if agent should handle event. */
 export const shouldHandleEventOf =
   (id: string, ignoreSelf: boolean, listen: string[]) =>
-  (event: Event): boolean => {
-    if (ignoreSelf === true && event.agent_id === id) {
-      return false;
-    }
-    return eventMatches(event, listen);
-  };
+    (event: Event): boolean => {
+      if (ignoreSelf && event.agent_id === id) {
+        return false;
+      }
+      return eventMatches(event, listen);
+    };
 
 export const agentSystemOf = (
   db: DatabaseSync,

--- a/src/agent-system.ts
+++ b/src/agent-system.ts
@@ -119,7 +119,7 @@ export const agentSystemOf = (
       agents.set(id, entry);
       forkAgentPollLoop(entry);
 
-      return config.id;
+      return id;
     } catch (e) {
       logger.error("Error spawning agent", {
         id,

--- a/src/agent-system.ts
+++ b/src/agent-system.ts
@@ -1,7 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import { eventMatches, type Event } from "./lib/event.ts";
 import { pullNextMatchingEvent, pushEvent } from "./event-queue.ts";
-import { abortableSleep } from "./lib/promise.ts";
+import { abortableSleep, nextTick } from "./lib/promise.ts";
 import { loggerOf } from "./lib/json-logger.ts";
 import { type Agent, type AgentSetup, type SendFn } from "./agent.ts";
 import { parseSlug } from "./lib/slug.ts";
@@ -101,6 +101,7 @@ export const agentSystemOf = (
     logger.debug("Spawning agent", { id });
 
     const send: SendFn = async (type, payload) => {
+      await nextTick();
       pushEvent(db, id, type, payload);
     };
 
@@ -134,9 +135,12 @@ export const agentSystemOf = (
     const entry = agents.get(id);
     if (!entry) return;
 
+    // First abort the poll loop
     entry.abortController.abort(new Error("Agent disposed"));
-    agents.delete(id);
+    // Then dispose the agent
     await entry.agent[Symbol.asyncDispose]();
+    // Then delete reference. Waiting to delete ref lets us retry dispose if it fails.
+    agents.delete(id);
     logger.debug("Disposed agent", { id });
   };
 

--- a/src/agent-system.ts
+++ b/src/agent-system.ts
@@ -34,6 +34,16 @@ type SpawnedAgent = {
   abortController: AbortController;
 };
 
+/** Create a predicate function that checks if agent should handle event. */
+export const shouldHandleEventOf =
+  (id: string, ignoreSelf: boolean, listen: string[]) =>
+  (event: Event): boolean => {
+    if (ignoreSelf === true && event.agent_id === id) {
+      return false;
+    }
+    return eventMatches(event, listen);
+  };
+
 export const agentSystemOf = (
   db: DatabaseSync,
   timeout = 1000,
@@ -56,12 +66,7 @@ export const agentSystemOf = (
       systemAbortController.signal,
     ]);
 
-    const shouldHandleEvent = (event: Event) => {
-      if (ignoreSelf !== false && event.agent_id === id) {
-        return false;
-      }
-      return eventMatches(event, listen);
-    };
+    const shouldHandleEvent = shouldHandleEventOf(id, ignoreSelf, listen);
 
     try {
       while (!signal.aborted) {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,41 +1,30 @@
-import type { Event, EventDraft } from "./lib/event.ts";
+import type { Event } from "./lib/event.ts";
+
+export type HandleOptions = {
+  signal?: AbortSignal;
+};
 
 /**
- * An agent process
- * Underlying implementation may be short lived or long-lived.
+ * An agent that handles events effectfully.
+ * The agent receives a `send` function at construction time, allowing it to
+ * emit events at any point in its lifecycle.
  */
-export type AgentProcess = {
+export type Agent = {
   /**
-   * Send an event and stream responses from the agent.
-   * Stream represents the responses for a single agent cycle, e.g.:
-   * ```
-   * user message -> (response -> tool call -> tool result -> response... -> final response)
-   * ```
-   * @throws {Error} if called after the disposed signal has been aborted.
-   * @returns a readable stream of event drafts.
+   * Effectful event handler.
+   * Promise signals when effects are complete. This can be used for
+   * backpressure.
    */
-  stream(event: Event): ReadableStream<EventDraft>;
-
-  /**
-   * Signals when the process is disposed.
-   * Implementors should abort the signal immediately when `agent.dispose()` is
-   * called, and not wait for disposal completion.
-   * Other methods such as `stream()` should throw an error when called after
-   * the disposed signal has been aborted.
-   */
-  disposed: AbortSignal;
-
-  /**
-   * Teardown and clean up any internal long-lived resources.
-   * Implementors should make this method idempotent.
-   * Calling this should also cause the `disposed` AbortSignal to be aborted.
-   * @returns promise for the completion of the teardown.
-   */
+  handle(event: Event, options?: HandleOptions): Promise<void>;
   [Symbol.asyncDispose](): Promise<void>;
 };
 
-export type Agent = AgentProcess & {
-  id: string;
-  listen: string[];
-  ignoreSelf: boolean;
-};
+/** Push an event to the queue */
+export type SendFn = (type: string, payload: unknown) => Promise<void>;
+
+/**
+ * Agent setup function. Receives the agent's id and a `send` function,
+ * and returns an agent. This allows agents to emit events during
+ * construction, and to know their own id for lifecycle events.
+ */
+export type AgentSetup = (id: string, send: SendFn) => Promise<Agent>;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,21 +139,19 @@ const startCommand = defineCommand({
 
       const dbPath = unwrap(toOption(db.location()), "No database location");
       for await (const agentPath of listAgentPaths(agentsDir)) {
-        const agent = loadFileAgentOf({
+        const config = loadFileAgentOf({
           path: agentPath,
           dbPath,
           cwd: projectRoot,
         });
-        system.registerAgent(agent);
+        await system.spawnAgent(config);
       }
 
-      system.registerAgent(
-        virtualAgentOf({
-          id: "_sys-reload",
-          listen: ["sys.reload"],
-          handler: () => reloadSystem(),
-        }),
-      );
+      await system.spawnAgent({
+        id: "_sys-reload",
+        listen: ["sys.reload"],
+        setup: virtualAgentOf(() => reloadSystem()),
+      });
 
       logger.info("Agent system started", { stats: system.stats() });
     };

--- a/src/file-agent.ts
+++ b/src/file-agent.ts
@@ -6,11 +6,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { glob as globDir } from "node:fs/promises";
 import { pathToSlug } from "./lib/slug.ts";
-import { type Agent } from "./agent.ts";
 import { piAgentOf } from "./pi-agent.ts";
 import { piRpcAgentOf } from "./pi-rpc-agent.ts";
 import { shellAgentOf } from "./shell-agent.ts";
 import { buildAgentAppendPrompt, guessProvider } from "./pi-agent-shared.ts";
+import type { AgentSetup } from "./agent.ts";
+import type { SpawnAgentConfig } from "./agent-system.ts";
 import {
   type MemoryBlock,
   MemoryBlockEntrySchema,
@@ -260,57 +261,50 @@ export type AgentConfig = {
   cwd: string;
 };
 
-export const loadFileAgentOf = (config: AgentConfig): Agent => {
-  const agentDef = loadAgentDef(config.path, config.cwd);
-
+const agentSetupOf = (agentDef: AgentDef, config: AgentConfig): AgentSetup => {
   const system = buildAgentAppendPrompt(agentDef);
+  const env = {
+    BUSYTOWN_DB_PATH: config.dbPath,
+    BUSYTOWN_AGENT_ID: agentDef.id,
+    BUSYTOWN_AGENT_FILE: config.path,
+  };
 
   switch (agentDef.type) {
     case "pi":
       return piAgentOf({
-        id: agentDef.id,
-        listen: agentDef.listen,
-        ignoreSelf: agentDef.ignoreSelf,
         model: agentDef.model,
         provider: agentDef.provider,
         system,
         extensions: [AGENT_EXTENSION_PATH],
-        env: {
-          BUSYTOWN_DB_PATH: config.dbPath,
-          BUSYTOWN_AGENT_ID: agentDef.id,
-          BUSYTOWN_AGENT_FILE: config.path,
-        },
+        env,
       });
     case "pi-rpc":
       return piRpcAgentOf({
-        id: agentDef.id,
-        listen: agentDef.listen,
-        ignoreSelf: agentDef.ignoreSelf,
         model: agentDef.model,
         provider: agentDef.provider,
         system,
         extensions: [AGENT_EXTENSION_PATH],
-        env: {
-          BUSYTOWN_DB_PATH: config.dbPath,
-          BUSYTOWN_AGENT_ID: agentDef.id,
-          BUSYTOWN_AGENT_FILE: config.path,
-        },
+        env,
       });
     case "shell":
       return shellAgentOf({
-        id: agentDef.id,
-        listen: agentDef.listen,
-        ignoreSelf: agentDef.ignoreSelf,
         shellScript: agentDef.body,
-        env: {
-          BUSYTOWN_DB_PATH: config.dbPath,
-          BUSYTOWN_AGENT_ID: agentDef.id,
-          BUSYTOWN_AGENT_FILE: config.path,
-        },
+        env,
       });
     case "claude":
       throw new Error("Claude agent not implemented yet");
   }
+};
+
+export const loadFileAgentOf = (config: AgentConfig): SpawnAgentConfig => {
+  const agentDef = loadAgentDef(config.path, config.cwd);
+
+  return {
+    id: agentDef.id,
+    listen: agentDef.listen,
+    ignoreSelf: agentDef.ignoreSelf,
+    setup: agentSetupOf(agentDef, config),
+  };
 };
 
 /**

--- a/src/mock-agent.ts
+++ b/src/mock-agent.ts
@@ -1,47 +1,29 @@
-import type { Event, EventDraft } from "./lib/event.ts";
-import type { Agent } from "./agent.ts";
+import type { Event } from "./lib/event.ts";
+import type { AgentSetup, SendFn } from "./agent.ts";
 
-export type MockAgentOpts = {
-  id: string;
-  listen?: string[];
-  ignoreSelf?: boolean;
-  onEvent?: (event: Event) => EventDraft[];
-};
-
-export type MockAgent = Agent & {
+export type MockAgent = {
   received: Event[];
+  setup: AgentSetup;
 };
 
-export const mockAgentOf = (opts: MockAgentOpts): MockAgent => {
-  const abortController = new AbortController();
+export const mockAgentOf = (
+  onEvent?: (send: SendFn, event: Event) => void | Promise<void>,
+): MockAgent => {
   const received: Event[] = [];
 
-  return {
-    id: opts.id,
-    listen: opts.listen ?? ["*"],
-    ignoreSelf: opts.ignoreSelf ?? true,
-    received,
-
-    stream(event: Event): ReadableStream<EventDraft> {
-      abortController.signal.throwIfAborted();
-      received.push(event);
-      const drafts = opts.onEvent?.(event) ?? [];
-      return new ReadableStream({
-        start(controller) {
-          for (const draft of drafts) {
-            controller.enqueue(draft);
-          }
-          controller.close();
-        },
-      });
-    },
-
-    disposed: abortController.signal,
-
-    async [Symbol.asyncDispose](): Promise<void> {
-      if (!abortController.signal.aborted) {
-        abortController.abort(new Error("Mock agent disposed"));
-      }
-    },
+  const setup: AgentSetup = async (_id, send) => {
+    let disposed = false;
+    return {
+      async handle(event) {
+        if (disposed) throw new Error("Mock agent disposed");
+        received.push(event);
+        await onEvent?.(send, event);
+      },
+      async [Symbol.asyncDispose]() {
+        disposed = true;
+      },
+    };
   };
+
+  return { received, setup };
 };

--- a/src/pi-agent.ts
+++ b/src/pi-agent.ts
@@ -11,10 +11,9 @@ import {
   fromPiAgentSessionEvent,
   type PiAgentSessionEvent,
 } from "./lib/agent-session-event.ts";
-import { type EventDraft, type Event } from "./lib/event.ts";
+import { type Event } from "./lib/event.ts";
 import { loggerOf } from "./lib/json-logger.ts";
-import type { Agent } from "./agent.ts";
-import { parseSlug } from "./lib/slug.ts";
+import type { AgentSetup, SendFn } from "./agent.ts";
 
 const logger = loggerOf({ source: "pi-agent.ts" });
 
@@ -32,9 +31,6 @@ type PiCliFlagConfig = {
 };
 
 export type PiAgentConfig = PiCliFlagConfig & {
-  id: string;
-  listen: string[];
-  ignoreSelf?: boolean;
   /** Working directory for the Pi process. Defaults to process.cwd(). */
   cwd?: string;
   /** Called for each line written to stderr by the Pi process. */
@@ -59,142 +55,103 @@ const buildCliArgs = (config: PiCliFlagConfig): string[] => {
 
 const onErrorNoOp = (): void => {};
 
-export const piAgentOf = (config: PiAgentConfig): Agent => {
-  const {
-    listen,
-    ignoreSelf = true,
-    onError = onErrorNoOp,
-    env,
-    cwd = process.cwd(),
-  } = config;
+const handleEvent = async (
+  id: string,
+  send: SendFn,
+  config: PiAgentConfig,
+  event: Event,
+): Promise<void> => {
+  const { onError = onErrorNoOp, env, cwd = process.cwd() } = config;
 
-  const id = parseSlug(config.id);
-  const agentAbortController = new AbortController();
+  const correlationId = `${event.id}`;
 
-  const stream = (event: Event): ReadableStream<EventDraft> => {
-    agentAbortController.signal.throwIfAborted();
+  const proc = spawn("pi", buildCliArgs(config), {
+    stdio: ["pipe", "pipe", "pipe"],
+    cwd,
+    env: { ...process.env, ...env },
+  });
 
-    const proc = spawn("pi", buildCliArgs(config), {
-      stdio: ["pipe", "pipe", "pipe"],
-      cwd,
-      env: { ...process.env, ...env },
+  // Write the event as the prompt to stdin, then close stdin
+  const stdinWriter = stdin(proc).getWriter();
+  writeJsonLine(stdinWriter, event)
+    .then(() => stdinWriter.close())
+    .catch(() => {});
+
+  // Pipe stderr to onError (fire-and-forget)
+  stderr(proc)
+    .pipeThrough(lineStream())
+    .pipeTo(
+      new WritableStream({
+        write(line) {
+          onError({ type: "error", message: line });
+          logger.error("stderr", { agent: id, line });
+        },
+      }),
+    )
+    .catch((e) => {
+      logger.error("stderr", { agent: id, error: `${e}` });
     });
 
-    // Write the event as the prompt to stdin, then close stdin
-    const stdinWriter = stdin(proc).getWriter();
-    writeJsonLine(stdinWriter, event)
-      .then(() => stdinWriter.close())
-      .catch(() => {});
+  // Parse stdout as JSONL PiAgentSessionEvent
+  const output: ReadableStream<PiAgentSessionEvent> = stdout(proc)
+    .pipeThrough(lineStream())
+    .pipeThrough(mapStream(JSON.parse));
 
-    // Pipe stderr to onError (fire-and-forget)
-    stderr(proc)
-      .pipeThrough(lineStream())
-      .pipeTo(
-        new WritableStream({
-          write(line) {
-            onError({ type: "error", message: line });
-            logger.error("stderr", { agent: id, line });
-          },
-        }),
-      )
-      .catch((e) => {
-        logger.error("stderr", { agent: id, error: `${e}` });
-      });
+  const reader = output.getReader();
 
-    // Parse stdout as JSONL PiAgentSessionEvent
-    const output: ReadableStream<PiAgentSessionEvent> = stdout(proc)
-      .pipeThrough(lineStream())
-      .pipeThrough(mapStream(JSON.parse));
+  const exitPromise = new Promise<{
+    code: number | null;
+    signal: string | null;
+  }>((resolve) => {
+    proc.once("exit", (code, signal) => resolve({ code, signal }));
+  });
 
-    const reader = output.getReader();
+  await send(`agent.${id}.start`, {
+    correlation_id: correlationId,
+    event_type: event.type,
+  });
 
-    const exitPromise = new Promise<{
-      code: number | null;
-      signal: string | null;
-    }>((resolve) => {
-      proc.once("exit", (code, signal) => resolve({ code, signal }));
-    });
-
-    const cleanup = () => {
-      reader.releaseLock();
-    };
-
-    const correlationId = `${event.id}`;
-
-    return new ReadableStream<EventDraft>(
-      {
-        start(controller) {
-          controller.enqueue({
-            type: `agent.${id}.start`,
-            payload: { correlation_id: correlationId, event_type: event.type },
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        const { code, signal } = await exitPromise;
+        if (code !== 0 && code !== null) {
+          await send(`agent.${id}.error`, {
+            correlation_id: correlationId,
+            code,
+            signal,
           });
-        },
-        async pull(controller) {
-          try {
-            const { done, value } = await reader.read();
-            if (done) {
-              const { code, signal } = await exitPromise;
-              if (code !== 0 && code !== null) {
-                controller.enqueue({
-                  type: `agent.${id}.error`,
-                  payload: { correlation_id: correlationId, code, signal },
-                });
-              }
-              controller.enqueue({
-                type: `agent.${id}.end`,
-                payload: { correlation_id: correlationId },
-              });
-              cleanup();
-              controller.close();
-              return;
-            }
+        }
+        break;
+      }
 
-            const sessionEvent = fromPiAgentSessionEvent(value, correlationId);
-            if (sessionEvent) {
-              controller.enqueue({
-                type: `agent.${id}.message`,
-                payload: value,
-              });
-            }
+      const sessionEvent = fromPiAgentSessionEvent(value, correlationId);
+      if (sessionEvent) {
+        await send(`agent.${id}.message`, value);
+      }
 
-            if (value.type === "agent_end") {
-              controller.enqueue({
-                type: `agent.${id}.end`,
-                payload: { correlation_id: correlationId },
-              });
-              cleanup();
-              controller.close();
-              return;
-            }
-          } catch (e) {
-            controller.enqueue({
-              type: `agent.${id}.error`,
-              payload: { correlation_id: correlationId, error: String(e) },
-            });
-            cleanup();
-            controller.error(e);
-          }
-        },
-        cancel() {
-          proc.kill("SIGTERM");
-          cleanup();
-        },
-      },
-      { highWaterMark: 0 },
-    );
-  };
-
-  const dispose = async (): Promise<void> => {
-    if (agentAbortController.signal.aborted) return;
-    agentAbortController.abort(new Error("Pi agent disposed"));
-  };
-
-  return {
-    id,
-    listen,
-    ignoreSelf,
-    stream,
-    disposed: agentAbortController.signal,
-    [Symbol.asyncDispose]: dispose,
-  };
+      if (value.type === "agent_end") {
+        break;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+    await send(`agent.${id}.end`, { correlation_id: correlationId });
+  }
 };
+
+export const piAgentOf =
+  (config: PiAgentConfig): AgentSetup =>
+  async (id, send) => {
+    let disposed = false;
+    return {
+      async handle(event) {
+        if (disposed) throw new Error("Pi agent disposed");
+        await handleEvent(id, send, config, event);
+      },
+      async [Symbol.asyncDispose]() {
+        disposed = true;
+      },
+    };
+  };

--- a/src/pi-agent.ts
+++ b/src/pi-agent.ts
@@ -55,110 +55,117 @@ const buildCliArgs = (config: PiCliFlagConfig): string[] => {
 
 const onErrorNoOp = (): void => {};
 
-const handleEvent = async (
-  id: string,
-  send: SendFn,
-  config: PiAgentConfig,
-  event: Event,
-  options?: HandleOptions,
-): Promise<void> => {
-  const { onError = onErrorNoOp, env, cwd = process.cwd() } = config;
+/** A signal that will never abort */
+const neverAbortSignal = new AbortController().signal;
 
-  const correlationId = `${event.id}`;
+export const piAgentOf = (config: PiAgentConfig): AgentSetup => {
+  return async (id, send) => {
+    const disposeController = new AbortController();
+    const { onError = onErrorNoOp, env, cwd = process.cwd() } = config;
 
-  const proc = spawn("pi", buildCliArgs(config), {
-    stdio: ["pipe", "pipe", "pipe"],
-    cwd,
-    env: { ...process.env, ...env },
-  });
+    const handle = async (
+      event: Event,
+      options: HandleOptions = {},
+    ): Promise<void> => {
+      if (disposeController.signal.aborted)
+        throw new Error("Pi agent disposed");
 
-  const onAbort = (): void => {
-    proc.kill("SIGTERM");
-  };
-  options?.signal?.addEventListener("abort", onAbort, { once: true });
+      const { signal: handleAbortSignal = neverAbortSignal } = options;
+      const abortSignal = AbortSignal.any([
+        disposeController.signal,
+        handleAbortSignal,
+      ]);
+      const correlationId = `${event.id}`;
 
-  // Write the event as the prompt to stdin, then close stdin
-  const stdinWriter = stdin(proc).getWriter();
-  writeJsonLine(stdinWriter, event)
-    .then(() => stdinWriter.close())
-    .catch(() => {});
+      const proc = spawn("pi", buildCliArgs(config), {
+        stdio: ["pipe", "pipe", "pipe"],
+        cwd,
+        env: { ...process.env, ...env },
+      });
 
-  // Pipe stderr to onError (fire-and-forget)
-  stderr(proc)
-    .pipeThrough(lineStream())
-    .pipeTo(
-      new WritableStream({
-        write(line) {
-          onError({ type: "error", message: line });
-          logger.error("stderr", { agent: id, line });
-        },
-      }),
-    )
-    .catch((e) => {
-      logger.error("stderr", { agent: id, error: `${e}` });
-    });
+      const onAbort = (): void => {
+        proc.kill("SIGTERM");
+      };
+      abortSignal.addEventListener("abort", onAbort, { once: true });
 
-  // Parse stdout as JSONL PiAgentSessionEvent
-  const output: ReadableStream<PiAgentSessionEvent> = stdout(proc)
-    .pipeThrough(lineStream())
-    .pipeThrough(mapStream(JSON.parse));
+      // Write the event as the prompt to stdin, then close stdin
+      const stdinWriter = stdin(proc).getWriter();
+      writeJsonLine(stdinWriter, event)
+        .then(() => stdinWriter.close())
+        .catch(() => {});
 
-  const reader = output.getReader();
+      // Pipe stderr to onError (fire-and-forget)
+      stderr(proc)
+        .pipeThrough(lineStream())
+        .pipeTo(
+          new WritableStream({
+            write(line) {
+              onError({ type: "error", message: line });
+              logger.error("stderr", { agent: id, line });
+            },
+          }),
+        )
+        .catch((e) => {
+          logger.error("stderr", { agent: id, error: `${e}` });
+        });
 
-  const exitPromise = new Promise<{
-    code: number | null;
-    signal: string | null;
-  }>((resolve) => {
-    proc.once("exit", (code, signal) => resolve({ code, signal }));
-  });
+      // Parse stdout as JSONL PiAgentSessionEvent
+      const output: ReadableStream<PiAgentSessionEvent> = stdout(proc)
+        .pipeThrough(lineStream())
+        .pipeThrough(mapStream(JSON.parse));
 
-  await send(`agent.${id}.start`, {
-    correlation_id: correlationId,
-    event_type: event.type,
-  });
+      const reader = output.getReader();
 
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        const { code, signal } = await exitPromise;
-        if (code !== 0 && code !== null) {
-          await send(`agent.${id}.error`, {
-            correlation_id: correlationId,
-            code,
-            signal,
-          });
+      const exitPromise = new Promise<{
+        code: number | null;
+        signal: string | null;
+      }>((resolve) => {
+        proc.once("exit", (code, signal) => resolve({ code, signal }));
+      });
+
+      await send(`agent.${id}.start`, {
+        correlation_id: correlationId,
+        event_type: event.type,
+      });
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            const { code, signal } = await exitPromise;
+            if (code !== 0 && code !== null) {
+              await send(`agent.${id}.error`, {
+                correlation_id: correlationId,
+                code,
+                signal,
+              });
+            }
+            break;
+          }
+
+          const sessionEvent = fromPiAgentSessionEvent(value, correlationId);
+          if (sessionEvent) {
+            await send(`agent.${id}.message`, value);
+          }
+
+          if (value.type === "agent_end") {
+            break;
+          }
         }
-        break;
+      } finally {
+        abortSignal.removeEventListener("abort", onAbort);
+        reader.releaseLock();
+        await send(`agent.${id}.end`, { correlation_id: correlationId });
       }
+    };
 
-      const sessionEvent = fromPiAgentSessionEvent(value, correlationId);
-      if (sessionEvent) {
-        await send(`agent.${id}.message`, value);
-      }
+    const dispose = async (): Promise<void> => {
+      disposeController.abort(new Error("Dispose pi-agent"));
+    };
 
-      if (value.type === "agent_end") {
-        break;
-      }
-    }
-  } finally {
-    options?.signal?.removeEventListener("abort", onAbort);
-    reader.releaseLock();
-    await send(`agent.${id}.end`, { correlation_id: correlationId });
-  }
-};
-
-export const piAgentOf =
-  (config: PiAgentConfig): AgentSetup =>
-  async (id, send) => {
-    let disposed = false;
     return {
-      async handle(event, options) {
-        if (disposed) throw new Error("Pi agent disposed");
-        await handleEvent(id, send, config, event, options);
-      },
-      async [Symbol.asyncDispose]() {
-        disposed = true;
-      },
+      handle,
+      [Symbol.asyncDispose]: dispose,
     };
   };
+};

--- a/src/pi-agent.ts
+++ b/src/pi-agent.ts
@@ -13,7 +13,7 @@ import {
 } from "./lib/agent-session-event.ts";
 import { type Event } from "./lib/event.ts";
 import { loggerOf } from "./lib/json-logger.ts";
-import type { AgentSetup, SendFn } from "./agent.ts";
+import type { AgentSetup, HandleOptions, SendFn } from "./agent.ts";
 
 const logger = loggerOf({ source: "pi-agent.ts" });
 
@@ -60,6 +60,7 @@ const handleEvent = async (
   send: SendFn,
   config: PiAgentConfig,
   event: Event,
+  options?: HandleOptions,
 ): Promise<void> => {
   const { onError = onErrorNoOp, env, cwd = process.cwd() } = config;
 
@@ -70,6 +71,11 @@ const handleEvent = async (
     cwd,
     env: { ...process.env, ...env },
   });
+
+  const onAbort = (): void => {
+    proc.kill("SIGTERM");
+  };
+  options?.signal?.addEventListener("abort", onAbort, { once: true });
 
   // Write the event as the prompt to stdin, then close stdin
   const stdinWriter = stdin(proc).getWriter();
@@ -136,6 +142,7 @@ const handleEvent = async (
       }
     }
   } finally {
+    options?.signal?.removeEventListener("abort", onAbort);
     reader.releaseLock();
     await send(`agent.${id}.end`, { correlation_id: correlationId });
   }
@@ -146,9 +153,9 @@ export const piAgentOf =
   async (id, send) => {
     let disposed = false;
     return {
-      async handle(event) {
+      async handle(event, options) {
         if (disposed) throw new Error("Pi agent disposed");
-        await handleEvent(id, send, config, event);
+        await handleEvent(id, send, config, event, options);
       },
       async [Symbol.asyncDispose]() {
         disposed = true;

--- a/src/pi-agent.ts
+++ b/src/pi-agent.ts
@@ -13,7 +13,7 @@ import {
 } from "./lib/agent-session-event.ts";
 import { type Event } from "./lib/event.ts";
 import { loggerOf } from "./lib/json-logger.ts";
-import type { AgentSetup, HandleOptions, SendFn } from "./agent.ts";
+import type { AgentSetup, HandleOptions } from "./agent.ts";
 
 const logger = loggerOf({ source: "pi-agent.ts" });
 
@@ -65,12 +65,12 @@ export const piAgentOf = (config: PiAgentConfig): AgentSetup => {
 
     const handle = async (
       event: Event,
-      options: HandleOptions = {},
+      { signal: handleAbortSignal = neverAbortSignal }: HandleOptions = {},
     ): Promise<void> => {
-      if (disposeController.signal.aborted)
+      if (disposeController.signal.aborted) {
         throw new Error("Pi agent disposed");
+      }
 
-      const { signal: handleAbortSignal = neverAbortSignal } = options;
       const abortSignal = AbortSignal.any([
         disposeController.signal,
         handleAbortSignal,

--- a/src/pi-agent.ts
+++ b/src/pi-agent.ts
@@ -135,6 +135,7 @@ export const piAgentOf = (config: PiAgentConfig): AgentSetup => {
             const { code, signal } = await exitPromise;
             if (code !== 0 && code !== null) {
               await send(`agent.${id}.error`, {
+                error: `Process exited unexpectedly (code ${code})`,
                 correlation_id: correlationId,
                 code,
                 signal,
@@ -145,17 +146,22 @@ export const piAgentOf = (config: PiAgentConfig): AgentSetup => {
 
           const sessionEvent = fromPiAgentSessionEvent(value, correlationId);
           if (sessionEvent) {
-            await send(`agent.${id}.message`, value);
+            await send(`agent.${id}.message`, sessionEvent);
           }
 
           if (value.type === "agent_end") {
+            await send(`agent.${id}.end`, { correlation_id: correlationId });
             break;
           }
         }
+      } catch (e) {
+        await send(`agent.${id}.error`, {
+          error: `${e}`,
+          correlation_id: correlationId,
+        });
       } finally {
         abortSignal.removeEventListener("abort", onAbort);
         reader.releaseLock();
-        await send(`agent.${id}.end`, { correlation_id: correlationId });
       }
     };
 

--- a/src/pi-rpc-agent.ts
+++ b/src/pi-rpc-agent.ts
@@ -115,13 +115,17 @@ export const piRpcAgentOf =
     let disposed = false;
 
     return {
-      async handle(event) {
+      async handle(event, options) {
         if (disposed) throw new Error("Pi RPC agent disposed");
 
         const correlationId = `${event.id}`;
 
         // Acquire exclusive lock on the output stream for this agent step
         const reader = output.getReader();
+
+        options?.signal?.addEventListener("abort", sendAbortCommandBestEffort, {
+          once: true,
+        });
 
         await send(`agent.${id}.start`, {
           correlation_id: correlationId,
@@ -153,6 +157,10 @@ export const piRpcAgentOf =
           });
           throw e;
         } finally {
+          options?.signal?.removeEventListener(
+            "abort",
+            sendAbortCommandBestEffort,
+          );
           reader.releaseLock();
           await send(`agent.${id}.end`, { correlation_id: correlationId });
         }

--- a/src/pi-rpc-agent.ts
+++ b/src/pi-rpc-agent.ts
@@ -58,9 +58,8 @@ const buildCliArgs = (config: PiRpcCliFlagConfig): string[] => {
 
 const onErrorNoOp = (): void => {};
 
-export const piRpcAgentOf =
-  (config: PiRpcAgentConfig): AgentSetup =>
-  async (id, send) => {
+export const piRpcAgentOf = (config: PiRpcAgentConfig): AgentSetup => {
+  return async (id, send) => {
     logger.debug("Creating RPC agent", { id });
 
     const { onError = onErrorNoOp, env, cwd = process.cwd() } = config;
@@ -143,26 +142,27 @@ export const piRpcAgentOf =
 
             const sessionEvent = fromPiAgentSessionEvent(value, correlationId);
             if (sessionEvent) {
-              await send(`agent.${id}.message`, value);
+              await send(`agent.${id}.message`, sessionEvent);
             }
 
             if (value.type === "agent_end") {
+              await send(`agent.${id}.end`, {
+                correlation_id: correlationId,
+              });
               break;
             }
           }
         } catch (e) {
           await send(`agent.${id}.error`, {
-            correlation_id: correlationId,
             error: String(e),
+            correlation_id: correlationId,
           });
-          throw e;
         } finally {
           options?.signal?.removeEventListener(
             "abort",
             sendAbortCommandBestEffort,
           );
           reader.releaseLock();
-          await send(`agent.${id}.end`, { correlation_id: correlationId });
         }
       },
 
@@ -181,3 +181,4 @@ export const piRpcAgentOf =
       },
     };
   };
+};

--- a/src/pi-rpc-agent.ts
+++ b/src/pi-rpc-agent.ts
@@ -11,19 +11,12 @@ import {
   fromPiAgentSessionEvent,
   type PiAgentSessionEvent,
 } from "./lib/agent-session-event.ts";
-import { type EventDraft, type Event } from "./lib/event.ts";
+import { type Event } from "./lib/event.ts";
 import { loggerOf } from "./lib/json-logger.ts";
 import type { PiRpcCommand } from "./pi-rpc-commands.ts";
-import type { Agent } from "./agent.ts";
-import { parseSlug } from "./lib/slug.ts";
+import type { AgentSetup, SendFn } from "./agent.ts";
 
 const logger = loggerOf({ source: "pi-rpc-agent.ts" });
-
-type AgentConfig = {
-  id: string;
-  listen: string[];
-  ignoreSelf?: boolean;
-};
 
 type PiRpcCliFlagConfig = {
   /** Pass --model to Pi. */
@@ -38,15 +31,14 @@ type PiRpcCliFlagConfig = {
   system?: string;
 };
 
-export type PiRpcAgentConfig = AgentConfig &
-  PiRpcCliFlagConfig & {
-    /** Working directory for the Pi process. Defaults to process.cwd(). */
-    cwd?: string;
-    /** Called for each line written to stderr by the Pi process. */
-    onError?: (error: { type: "error"; message: string }) => void;
-    /** Extra environment variables passed to the Pi process. Process.env is merged with this object. */
-    env?: Record<string, string | undefined>;
-  };
+export type PiRpcAgentConfig = PiRpcCliFlagConfig & {
+  /** Working directory for the Pi process. Defaults to process.cwd(). */
+  cwd?: string;
+  /** Called for each line written to stderr by the Pi process. */
+  onError?: (error: { type: "error"; message: string }) => void;
+  /** Extra environment variables passed to the Pi process. Process.env is merged with this object. */
+  env?: Record<string, string | undefined>;
+};
 
 const buildCliArgs = (config: PiRpcCliFlagConfig): string[] => {
   const args = ["--mode", "rpc"];
@@ -66,196 +58,118 @@ const buildCliArgs = (config: PiRpcCliFlagConfig): string[] => {
 
 const onErrorNoOp = (): void => {};
 
-export const piRpcAgentOf = (config: PiRpcAgentConfig): Agent => {
-  logger.debug("Creating agent", { id: config.id });
+export const piRpcAgentOf =
+  (config: PiRpcAgentConfig): AgentSetup =>
+  async (id, send) => {
+    logger.debug("Creating RPC agent", { id });
 
-  const {
-    listen,
-    ignoreSelf = true,
-    onError = onErrorNoOp,
-    env,
-    cwd = process.cwd(),
-  } = config;
+    const { onError = onErrorNoOp, env, cwd = process.cwd() } = config;
 
-  // Make sure we have a valid ID. Throws if not.
-  const id = parseSlug(config.id);
-
-  const processAbortController = new AbortController();
-
-  const proc = spawn("pi", buildCliArgs(config), {
-    stdio: ["pipe", "pipe", "pipe"],
-    cwd,
-    env: { ...process.env, ...env },
-  });
-
-  const stdin = Writable.toWeb(proc.stdin) as WritableStream<Uint8Array>;
-  const stdinWriter = stdin.getWriter();
-
-  const sendCommand = (command: PiRpcCommand): Promise<void> =>
-    writeJsonLine(stdinWriter, command);
-
-  const sendEventPromptCommand = (event: Event): Promise<void> =>
-    sendCommand({
-      type: "prompt",
-      message: JSON.stringify(event),
+    const proc = spawn("pi", buildCliArgs(config), {
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd,
+      env: { ...process.env, ...env },
     });
 
-  const sendAbortCommandBestEffort = async (): Promise<void> => {
-    try {
-      await sendCommand({ type: "abort" });
-    } catch (e) {
-      onError({ type: "error", message: "Failed to write abort command" });
-      logger.error("Failed to write abort command", { error: `${e}` });
-    }
-  };
+    const stdinStream = Writable.toWeb(
+      proc.stdin,
+    ) as WritableStream<Uint8Array>;
+    const stdinWriter = stdinStream.getWriter();
 
-  // Convert stdout to a web ReadableStream of JSONL lines
-  const output: ReadableStream<PiAgentSessionEvent> = stdout(proc)
-    .pipeThrough(lineStream())
-    .pipeThrough(mapStream(JSON.parse));
+    const sendCommand = (command: PiRpcCommand): Promise<void> =>
+      writeJsonLine(stdinWriter, command);
 
-  // Pipe stderr lines to onError callback
-  stderr(proc)
-    .pipeThrough(lineStream())
-    .pipeTo(
-      new WritableStream({
-        write(line) {
-          onError({ type: "error", message: line });
-          logger.error("stderr", { line });
-        },
-      }),
-    )
-    .catch(() => {});
+    const sendEventPromptCommand = (event: Event): Promise<void> =>
+      sendCommand({
+        type: "prompt",
+        message: JSON.stringify(event),
+      });
 
-  // Handle process death. Make sure we've aborted if we haven't already.
-  proc.once("exit", (code) => {
-    processAbortController.abort(
-      new Error(`Pi process exited (code: ${code ?? "null"})`),
-    );
-  });
-
-  const stream = (event: Event): ReadableStream<EventDraft> => {
-    processAbortController.signal.throwIfAborted();
-
-    // Acquire exclusive lock on the output stream for the duration of this
-    // agent step
-    const reader = output.getReader();
-
-    const cleanup = () => {
-      reader.releaseLock();
-    };
-
-    const drainUntilAgentEnd = async (): Promise<void> => {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done || value.type === "agent_end") break;
+    const sendAbortCommandBestEffort = async (): Promise<void> => {
+      try {
+        await sendCommand({ type: "abort" });
+      } catch (e) {
+        onError({ type: "error", message: "Failed to write abort command" });
+        logger.error("Failed to write abort command", { error: `${e}` });
       }
     };
 
-    const correlationId = `${event.id}`;
+    // Convert stdout to a web ReadableStream of JSONL lines
+    const output: ReadableStream<PiAgentSessionEvent> = stdout(proc)
+      .pipeThrough(lineStream())
+      .pipeThrough(mapStream(JSON.parse));
 
-    return new ReadableStream<EventDraft>(
-      {
-        async start(controller) {
-          try {
-            controller.enqueue({
-              type: `agent.${id}.start`,
-              payload: {
-                correlation_id: correlationId,
-                event_type: event.type,
-              },
-            });
-            // Write the prompt command to Pi's stdin
-            await sendEventPromptCommand(event);
-          } catch (e) {
-            cleanup();
-            throw e;
-          }
-        },
-        async pull(controller) {
-          try {
-            // Get next value
+    // Pipe stderr lines to onError callback
+    stderr(proc)
+      .pipeThrough(lineStream())
+      .pipeTo(
+        new WritableStream({
+          write(line) {
+            onError({ type: "error", message: line });
+            logger.error("stderr", { line });
+          },
+        }),
+      )
+      .catch(() => {});
+
+    let disposed = false;
+
+    return {
+      async handle(event) {
+        if (disposed) throw new Error("Pi RPC agent disposed");
+
+        const correlationId = `${event.id}`;
+
+        // Acquire exclusive lock on the output stream for this agent step
+        const reader = output.getReader();
+
+        await send(`agent.${id}.start`, {
+          correlation_id: correlationId,
+          event_type: event.type,
+        });
+
+        try {
+          await sendEventPromptCommand(event);
+
+          while (true) {
             const { done, value } = await reader.read();
-            // If done, it means the pi process exited.
-            // Clean up and close this stream.
             if (done) {
-              controller.enqueue({
-                type: `agent.${id}.end`,
-                payload: { correlation_id: correlationId },
-              });
-              cleanup();
-              controller.close();
-              return;
+              break;
             }
 
             const sessionEvent = fromPiAgentSessionEvent(value, correlationId);
             if (sessionEvent) {
-              // Enqueue the value.
-              controller.enqueue({
-                type: `agent.${id}.message`,
-                payload: value,
-              });
+              await send(`agent.${id}.message`, value);
             }
 
-            // If it's the agent_end, then we clean up (release the lock on upstream)
-            // and close this step's stream.
             if (value.type === "agent_end") {
-              controller.enqueue({
-                type: `agent.${id}.end`,
-                payload: { correlation_id: correlationId },
-              });
-              cleanup();
-              controller.close();
-              return;
+              break;
             }
-          } catch (e) {
-            controller.enqueue({
-              type: `agent.${id}.error`,
-              payload: { correlation_id: correlationId, error: String(e) },
-            });
-            cleanup();
-            controller.error(e);
           }
-        },
-        async cancel() {
-          try {
-            await sendAbortCommandBestEffort();
-            await drainUntilAgentEnd();
-          } catch (e) {
-            logger.error("Error cancelling stream", { error: `${e}` });
-            throw e;
-          } finally {
-            cleanup();
-          }
-        },
+        } catch (e) {
+          await send(`agent.${id}.error`, {
+            correlation_id: correlationId,
+            error: String(e),
+          });
+          throw e;
+        } finally {
+          reader.releaseLock();
+          await send(`agent.${id}.end`, { correlation_id: correlationId });
+        }
       },
-      { highWaterMark: 0 },
-    );
-  };
 
-  const dispose = async (): Promise<void> => {
-    logger.debug("Disposing agent", { id: config.id });
-    if (processAbortController.signal.aborted) return;
-    // Abort immediately
-    processAbortController.abort(new Error(`Pi process aborted via kill()`));
-    await sendAbortCommandBestEffort();
-    // Promise for completion of teardown
-    return new Promise<void>((resolve) => {
-      const onExit = (code: number): void => {
-        logger.debug("Agent process exited", { id: config.id, code });
-        resolve();
-      };
-      proc.once("exit", onExit);
-      proc.kill("SIGTERM");
-    });
+      async [Symbol.asyncDispose]() {
+        if (disposed) return;
+        disposed = true;
+        logger.debug("Disposing RPC agent", { id });
+        await sendAbortCommandBestEffort();
+        return new Promise<void>((resolve) => {
+          proc.once("exit", (code) => {
+            logger.debug("RPC agent process exited", { id, code });
+            resolve();
+          });
+          proc.kill("SIGTERM");
+        });
+      },
+    };
   };
-
-  return {
-    id,
-    listen,
-    ignoreSelf,
-    disposed: processAbortController.signal,
-    stream,
-    [Symbol.asyncDispose]: dispose,
-  };
-};

--- a/src/pi-rpc-agent.ts
+++ b/src/pi-rpc-agent.ts
@@ -14,7 +14,7 @@ import {
 import { type Event } from "./lib/event.ts";
 import { loggerOf } from "./lib/json-logger.ts";
 import type { PiRpcCommand } from "./pi-rpc-commands.ts";
-import type { AgentSetup, SendFn } from "./agent.ts";
+import type { AgentSetup } from "./agent.ts";
 
 const logger = loggerOf({ source: "pi-rpc-agent.ts" });
 

--- a/src/shell-agent.test.ts
+++ b/src/shell-agent.test.ts
@@ -53,9 +53,7 @@ describe("handle", () => {
     assert.ok(types.includes("agent.echo-agent.start"));
     assert.ok(types.includes("agent.echo-agent.end"));
 
-    const responses = sent.filter(
-      (s) => s.type === "agent.echo-agent.response",
-    );
+    const responses = sent.filter((s) => s.type === "agent.echo-agent.output");
     assert.equal(responses.length, 2);
     assert.deepEqual(responses[0].payload, { line: "line one" });
     assert.deepEqual(responses[1].payload, { line: "line two" });
@@ -72,7 +70,7 @@ describe("handle", () => {
       await agent.handle(testEvent({ type: "task.created" }));
 
       const responses = sent.filter(
-        (s) => s.type === "agent.template-agent.response",
+        (s) => s.type === "agent.template-agent.output",
       );
       assert.equal(responses.length, 1);
       assert.deepEqual(responses[0].payload, { line: "task.created" });
@@ -89,7 +87,7 @@ describe("handle", () => {
     await agent.handle(testEvent({ payload: { message: "hello" } }));
 
     const responses = sent.filter(
-      (s) => s.type === "agent.nested-agent.response",
+      (s) => s.type === "agent.nested-agent.output",
     );
     assert.equal(responses.length, 1);
     assert.deepEqual(responses[0].payload, { line: "hello" });
@@ -112,7 +110,7 @@ describe("handle", () => {
       assert.equal((errors[0].payload as { code: number }).code, 1);
 
       const ends = sent.filter((s) => s.type === "agent.fail-agent.end");
-      assert.equal(ends.length, 1);
+      assert.equal(ends.length, 0);
     },
   );
 

--- a/src/shell-agent.test.ts
+++ b/src/shell-agent.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { shellAgentOf } from "./shell-agent.ts";
 import type { Event } from "./lib/event.ts";
-import { collect } from "./lib/generator.ts";
+import type { SendFn } from "./agent.ts";
 
 const testEvent = (overrides: Partial<Event> = {}): Event => ({
   id: 1,
@@ -13,130 +13,106 @@ const testEvent = (overrides: Partial<Event> = {}): Event => ({
   ...overrides,
 });
 
+const collectSent = (): {
+  sent: Array<{ type: string; payload: unknown }>;
+  send: SendFn;
+} => {
+  const sent: Array<{ type: string; payload: unknown }> = [];
+  const send: SendFn = async (type, payload) => {
+    sent.push({ type, payload });
+  };
+  return { sent, send };
+};
+
 describe("shellAgentOf", () => {
   it(
-    "returns an agent with the configured properties",
+    "returns an AgentSetup that creates an agent",
     { timeout: 2000 },
-    () => {
-      const agent = shellAgentOf({
-        id: "my-agent",
-        listen: ["test.*"],
-        shellScript: "echo hi",
-      });
+    async () => {
+      const setup = shellAgentOf({ shellScript: "echo hi" });
+      const { send } = collectSent();
+      const agent = await setup("my-agent", send);
 
-      assert.equal(agent.id, "my-agent");
-      assert.deepEqual(agent.listen, ["test.*"]);
-      assert.equal(agent.ignoreSelf, true);
-      assert.equal(agent.disposed.aborted, false);
+      assert.equal(typeof agent.handle, "function");
+      assert.equal(typeof agent[Symbol.asyncDispose], "function");
     },
   );
-
-  it("defaults ignoreSelf to true", { timeout: 2000 }, () => {
-    const agent = shellAgentOf({
-      id: "agent",
-      listen: [],
-      shellScript: "echo hi",
-    });
-    assert.equal(agent.ignoreSelf, true);
-  });
-
-  it("respects ignoreSelf config", { timeout: 2000 }, () => {
-    const agent = shellAgentOf({
-      id: "agent",
-      listen: [],
-      ignoreSelf: true,
-      shellScript: "echo hi",
-    });
-    assert.equal(agent.ignoreSelf, true);
-  });
 });
 
-describe("stream", () => {
-  it("streams stdout lines as response events", { timeout: 2000 }, async () => {
-    const agent = shellAgentOf({
-      id: "echo-agent",
-      listen: ["*"],
+describe("handle", () => {
+  it("sends stdout lines as response events", { timeout: 2000 }, async () => {
+    const setup = shellAgentOf({
       shellScript: 'echo "line one" && echo "line two"',
     });
+    const { sent, send } = collectSent();
+    const agent = await setup("echo-agent", send);
 
-    const drafts = await collect(agent.stream(testEvent()));
+    await agent.handle(testEvent());
 
-    assert.equal(drafts.length, 4);
-    assert.equal(drafts[0].type, "agent.echo-agent.start");
-    assert.deepEqual(drafts[1], {
-      type: "agent.echo-agent.response",
-      payload: { line: "line one" },
-    });
-    assert.deepEqual(drafts[2], {
-      type: "agent.echo-agent.response",
-      payload: { line: "line two" },
-    });
-    assert.equal(drafts[3].type, "agent.echo-agent.end");
+    const types = sent.map((s) => s.type);
+    assert.ok(types.includes("agent.echo-agent.start"));
+    assert.ok(types.includes("agent.echo-agent.end"));
+
+    const responses = sent.filter(
+      (s) => s.type === "agent.echo-agent.response",
+    );
+    assert.equal(responses.length, 2);
+    assert.deepEqual(responses[0].payload, { line: "line one" });
+    assert.deepEqual(responses[1].payload, { line: "line two" });
   });
 
   it(
     "templates event fields into the shell script",
     { timeout: 2000 },
     async () => {
-      const agent = shellAgentOf({
-        id: "template-agent",
-        listen: ["*"],
-        shellScript: "echo {{type}}",
-      });
+      const setup = shellAgentOf({ shellScript: "echo {{type}}" });
+      const { sent, send } = collectSent();
+      const agent = await setup("template-agent", send);
 
-      const event = testEvent({ type: "task.created" });
-      const drafts = await collect(agent.stream(event));
+      await agent.handle(testEvent({ type: "task.created" }));
 
-      assert.equal(drafts.length, 3);
-      assert.equal(drafts[0].type, "agent.template-agent.start");
-      assert.deepEqual(drafts[1], {
-        type: "agent.template-agent.response",
-        payload: { line: "task.created" },
-      });
-      assert.equal(drafts[2].type, "agent.template-agent.end");
+      const responses = sent.filter(
+        (s) => s.type === "agent.template-agent.response",
+      );
+      assert.equal(responses.length, 1);
+      assert.deepEqual(responses[0].payload, { line: "task.created" });
     },
   );
 
   it("templates nested payload fields", { timeout: 2000 }, async () => {
-    const agent = shellAgentOf({
-      id: "nested-agent",
-      listen: ["*"],
+    const setup = shellAgentOf({
       shellScript: "echo {{{payload.message}}}",
     });
+    const { sent, send } = collectSent();
+    const agent = await setup("nested-agent", send);
 
-    const event = testEvent({ payload: { message: "hello" } });
-    const drafts = await collect(agent.stream(event));
+    await agent.handle(testEvent({ payload: { message: "hello" } }));
 
-    assert.equal(drafts.length, 3);
-    assert.equal(drafts[0].type, "agent.nested-agent.start");
-    assert.deepEqual(drafts[1], {
-      type: "agent.nested-agent.response",
-      payload: { line: "hello" },
-    });
-    assert.equal(drafts[2].type, "agent.nested-agent.end");
+    const responses = sent.filter(
+      (s) => s.type === "agent.nested-agent.response",
+    );
+    assert.equal(responses.length, 1);
+    assert.deepEqual(responses[0].payload, { line: "hello" });
   });
 
   it(
-    "emits an error event on non-zero exit code",
+    "sends an error event on non-zero exit code",
     { timeout: 2000 },
     async () => {
-      const agent = shellAgentOf({
-        id: "fail-agent",
-        listen: ["*"],
+      const setup = shellAgentOf({
         shellScript: "echo before && exit 1",
       });
+      const { sent, send } = collectSent();
+      const agent = await setup("fail-agent", send);
 
-      const drafts = await collect(agent.stream(testEvent()));
+      await agent.handle(testEvent());
 
-      assert.equal(drafts.length, 4);
-      assert.equal(drafts[0].type, "agent.fail-agent.start");
-      assert.deepEqual(drafts[1], {
-        type: "agent.fail-agent.response",
-        payload: { line: "before" },
-      });
-      assert.equal(drafts[2].type, "agent.fail-agent.error");
-      assert.equal((drafts[2].payload as { code: number }).code, 1);
-      assert.equal(drafts[3].type, "agent.fail-agent.end");
+      const errors = sent.filter((s) => s.type === "agent.fail-agent.error");
+      assert.equal(errors.length, 1);
+      assert.equal((errors[0].payload as { code: number }).code, 1);
+
+      const ends = sent.filter((s) => s.type === "agent.fail-agent.end");
+      assert.equal(ends.length, 1);
     },
   );
 
@@ -144,77 +120,40 @@ describe("stream", () => {
     "closes cleanly for a script with no output",
     { timeout: 2000 },
     async () => {
-      const agent = shellAgentOf({
-        id: "silent-agent",
-        listen: ["*"],
-        shellScript: "true",
-      });
+      const setup = shellAgentOf({ shellScript: "true" });
+      const { sent, send } = collectSent();
+      const agent = await setup("silent-agent", send);
 
-      const drafts = await collect(agent.stream(testEvent()));
-      assert.equal(drafts.length, 2);
-      assert.equal(drafts[0].type, "agent.silent-agent.start");
-      assert.equal(drafts[1].type, "agent.silent-agent.end");
+      await agent.handle(testEvent());
+
+      const types = sent.map((s) => s.type);
+      assert.ok(types.includes("agent.silent-agent.start"));
+      assert.ok(types.includes("agent.silent-agent.end"));
+
+      const responses = sent.filter(
+        (s) => s.type === "agent.silent-agent.response",
+      );
+      assert.equal(responses.length, 0);
     },
   );
-
-  it("supports cancellation via stream cancel", { timeout: 2000 }, async () => {
-    const agent = shellAgentOf({
-      id: "cancel-agent",
-      listen: ["*"],
-      shellScript: "echo start && sleep 60",
-    });
-
-    const stream = agent.stream(testEvent());
-    const reader = stream.getReader();
-
-    // First event is the start lifecycle event
-    const { value: startEvent } = await reader.read();
-    assert.equal(startEvent!.type, "agent.cancel-agent.start");
-
-    const { value } = await reader.read();
-    assert.deepEqual(value, {
-      type: "agent.cancel-agent.response",
-      payload: { line: "start" },
-    });
-
-    // Cancel the stream, which should kill the process
-    await reader.cancel();
-  });
 });
 
 describe("dispose", () => {
-  it("sets disposed signal to aborted", { timeout: 2000 }, async () => {
-    const agent = shellAgentOf({
-      id: "dispose-agent",
-      listen: ["*"],
-      shellScript: "echo hi",
-    });
+  it("throws on handle after dispose", { timeout: 2000 }, async () => {
+    const setup = shellAgentOf({ shellScript: "echo hi" });
+    const { send } = collectSent();
+    const agent = await setup("disposed-agent", send);
 
-    assert.equal(agent.disposed.aborted, false);
     await agent[Symbol.asyncDispose]();
-    assert.equal(agent.disposed.aborted, true);
+    await assert.rejects(() => agent.handle(testEvent()), /disposed/i);
   });
 
   it("is idempotent", { timeout: 2000 }, async () => {
-    const agent = shellAgentOf({
-      id: "dispose-agent",
-      listen: ["*"],
-      shellScript: "echo hi",
-    });
+    const setup = shellAgentOf({ shellScript: "echo hi" });
+    const { send } = collectSent();
+    const agent = await setup("dispose-agent", send);
 
     await agent[Symbol.asyncDispose]();
-    await agent[Symbol.asyncDispose]();
-    assert.equal(agent.disposed.aborted, true);
-  });
-
-  it("throws on stream after dispose", { timeout: 2000 }, async () => {
-    const agent = shellAgentOf({
-      id: "disposed-agent",
-      listen: ["*"],
-      shellScript: "echo hi",
-    });
-
-    await agent[Symbol.asyncDispose]();
-    assert.throws(() => agent.stream(testEvent()));
+    await agent[Symbol.asyncDispose](); // Should not throw
   });
 });

--- a/src/shell-agent.ts
+++ b/src/shell-agent.ts
@@ -24,8 +24,9 @@ export const shellAgentOf = (config: ShellAgentConfig): AgentSetup => {
       event: Event,
       { signal: handleAbortSignal = neverAbortSignal }: HandleOptions = {},
     ): Promise<void> => {
-      if (disposeController.signal.aborted)
+      if (disposeController.signal.aborted) {
         throw new Error("Shell agent disposed");
+      }
 
       const abortSignal = AbortSignal.any([
         disposeController.signal,

--- a/src/shell-agent.ts
+++ b/src/shell-agent.ts
@@ -3,7 +3,7 @@ import { type Event } from "./lib/event.ts";
 import { loggerOf } from "./lib/json-logger.ts";
 import { renderTemplate } from "./lib/template.ts";
 import { stderr, stdout, lineStream } from "./lib/web-stream.ts";
-import type { AgentSetup, SendFn } from "./agent.ts";
+import type { AgentSetup, HandleOptions, SendFn } from "./agent.ts";
 
 const logger = loggerOf({ source: "shell-agent.ts" });
 
@@ -17,6 +17,7 @@ const handleEvent = async (
   send: SendFn,
   config: ShellAgentConfig,
   event: Event,
+  options?: HandleOptions,
 ): Promise<void> => {
   const { shellScript, env = {} } = config;
   const correlationId = `${event.id}`;
@@ -30,6 +31,11 @@ const handleEvent = async (
     stdio: ["ignore", "pipe", "pipe"],
     env: { ...process.env, ...env },
   });
+
+  const onAbort = (): void => {
+    proc.kill("SIGTERM");
+  };
+  options?.signal?.addEventListener("abort", onAbort, { once: true });
 
   // Pipe stderr to logger (fire-and-forget)
   stderr(proc)
@@ -75,6 +81,7 @@ const handleEvent = async (
       await send(`agent.${id}.response`, { line: value });
     }
   } finally {
+    options?.signal?.removeEventListener("abort", onAbort);
     reader.releaseLock();
     await send(`agent.${id}.end`, { correlation_id: correlationId });
   }
@@ -85,9 +92,9 @@ export const shellAgentOf =
   async (id, send) => {
     let disposed = false;
     return {
-      async handle(event) {
+      async handle(event, options) {
         if (disposed) throw new Error("Shell agent disposed");
-        await handleEvent(id, send, config, event);
+        await handleEvent(id, send, config, event, options);
       },
       async [Symbol.asyncDispose]() {
         disposed = true;

--- a/src/shell-agent.ts
+++ b/src/shell-agent.ts
@@ -1,129 +1,96 @@
 import { spawn } from "node:child_process";
-import type { Agent } from "./agent.ts";
-import { type EventDraft, type Event } from "./lib/event.ts";
+import { type Event } from "./lib/event.ts";
 import { loggerOf } from "./lib/json-logger.ts";
-import { parseSlug } from "./lib/slug.ts";
 import { renderTemplate } from "./lib/template.ts";
 import { stderr, stdout, lineStream } from "./lib/web-stream.ts";
+import type { AgentSetup, SendFn } from "./agent.ts";
 
 const logger = loggerOf({ source: "shell-agent.ts" });
 
 export type ShellAgentConfig = {
-  id: string;
-  listen: string[];
-  ignoreSelf?: boolean;
   shellScript: string;
   env?: Record<string, string | undefined>;
 };
 
-export const shellAgentOf = (config: ShellAgentConfig): Agent => {
-  const { listen, ignoreSelf = true, shellScript, env = {} } = config;
-  const id = parseSlug(config.id);
-  const agentAbortController = new AbortController();
+const handleEvent = async (
+  id: string,
+  send: SendFn,
+  config: ShellAgentConfig,
+  event: Event,
+): Promise<void> => {
+  const { shellScript, env = {} } = config;
+  const correlationId = `${event.id}`;
 
-  const stream = (event: Event): ReadableStream<EventDraft> => {
-    agentAbortController.signal.throwIfAborted();
+  const rendered = renderTemplate(
+    shellScript,
+    event as unknown as Record<string, unknown>,
+  );
 
-    const rendered = renderTemplate(
-      shellScript,
-      event as unknown as Record<string, unknown>,
-    );
+  const proc = spawn("/bin/sh", ["-c", rendered], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...env },
+  });
 
-    const proc = spawn("/bin/sh", ["-c", rendered], {
-      stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, ...env },
-    });
+  // Pipe stderr to logger (fire-and-forget)
+  stderr(proc)
+    .pipeThrough(lineStream())
+    .pipeTo(
+      new WritableStream({
+        write(line) {
+          logger.warn("stderr", { agent: id, line });
+        },
+      }),
+    )
+    .catch(() => {});
 
-    // Pipe stderr to logger (fire-and-forget)
-    stderr(proc)
-      .pipeThrough(lineStream())
-      .pipeTo(
-        new WritableStream({
-          write(line) {
-            logger.warn("stderr", { agent: id, line });
-          },
-        }),
-      )
-      .catch(() => {});
+  const lines = stdout(proc).pipeThrough(lineStream());
+  const reader = lines.getReader();
 
-    // Build stdout line stream
-    const lines = stdout(proc).pipeThrough(lineStream());
+  const exitPromise = new Promise<{
+    code: number | null;
+    signal: string | null;
+  }>((resolve) => {
+    proc.once("exit", (code, signal) => resolve({ code, signal }));
+  });
 
-    const reader = lines.getReader();
+  await send(`agent.${id}.start`, {
+    correlation_id: correlationId,
+    event_type: event.type,
+  });
 
-    const exitPromise = new Promise<{
-      code: number | null;
-      signal: string | null;
-    }>((resolve) => {
-      proc.once("exit", (code, signal) => resolve({ code, signal }));
-    });
-
-    const cleanup = () => {
-      reader.releaseLock();
-    };
-
-    const correlationId = `${event.id}`;
-
-    return new ReadableStream<EventDraft>(
-      {
-        start(controller) {
-          controller.enqueue({
-            type: `agent.${id}.start`,
-            payload: { correlation_id: correlationId, event_type: event.type },
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        const { code, signal } = await exitPromise;
+        if (code !== 0 && code !== null) {
+          await send(`agent.${id}.error`, {
+            correlation_id: correlationId,
+            code,
+            signal,
           });
-        },
-        async pull(controller) {
-          try {
-            const { done, value } = await reader.read();
-            if (done) {
-              const { code, signal } = await exitPromise;
-              if (code !== 0 && code !== null) {
-                controller.enqueue({
-                  type: `agent.${id}.error`,
-                  payload: { correlation_id: correlationId, code, signal },
-                });
-              }
-              controller.enqueue({
-                type: `agent.${id}.end`,
-                payload: { correlation_id: correlationId },
-              });
-              cleanup();
-              controller.close();
-              return;
-            }
-            controller.enqueue({
-              type: `agent.${id}.response`,
-              payload: { line: value },
-            });
-          } catch (e) {
-            controller.enqueue({
-              type: `agent.${id}.error`,
-              payload: { correlation_id: correlationId, error: String(e) },
-            });
-            cleanup();
-            controller.error(e);
-          }
-        },
-        cancel() {
-          proc.kill("SIGTERM");
-          cleanup();
-        },
-      },
-      { highWaterMark: 0 },
-    );
-  };
-
-  const asyncDispose = async (): Promise<void> => {
-    if (agentAbortController.signal.aborted) return;
-    agentAbortController.abort(new Error("Shell agent disposed"));
-  };
-
-  return {
-    id,
-    listen,
-    ignoreSelf,
-    stream,
-    disposed: agentAbortController.signal,
-    [Symbol.asyncDispose]: asyncDispose,
-  };
+        }
+        break;
+      }
+      await send(`agent.${id}.response`, { line: value });
+    }
+  } finally {
+    reader.releaseLock();
+    await send(`agent.${id}.end`, { correlation_id: correlationId });
+  }
 };
+
+export const shellAgentOf =
+  (config: ShellAgentConfig): AgentSetup =>
+  async (id, send) => {
+    let disposed = false;
+    return {
+      async handle(event) {
+        if (disposed) throw new Error("Shell agent disposed");
+        await handleEvent(id, send, config, event);
+      },
+      async [Symbol.asyncDispose]() {
+        disposed = true;
+      },
+    };
+  };

--- a/src/shell-agent.ts
+++ b/src/shell-agent.ts
@@ -3,7 +3,7 @@ import { type Event } from "./lib/event.ts";
 import { loggerOf } from "./lib/json-logger.ts";
 import { renderTemplate } from "./lib/template.ts";
 import { stderr, stdout, lineStream } from "./lib/web-stream.ts";
-import type { AgentSetup, HandleOptions, SendFn } from "./agent.ts";
+import type { AgentSetup, HandleOptions } from "./agent.ts";
 
 const logger = loggerOf({ source: "shell-agent.ts" });
 
@@ -12,92 +12,99 @@ export type ShellAgentConfig = {
   env?: Record<string, string | undefined>;
 };
 
-const handleEvent = async (
-  id: string,
-  send: SendFn,
-  config: ShellAgentConfig,
-  event: Event,
-  options?: HandleOptions,
-): Promise<void> => {
-  const { shellScript, env = {} } = config;
-  const correlationId = `${event.id}`;
+/** A signal that will never abort */
+const neverAbortSignal = new AbortController().signal;
 
-  const rendered = renderTemplate(
-    shellScript,
-    event as unknown as Record<string, unknown>,
-  );
+export const shellAgentOf = (config: ShellAgentConfig): AgentSetup => {
+  return async (id, send) => {
+    const disposeController = new AbortController();
+    const { shellScript, env = {} } = config;
 
-  const proc = spawn("/bin/sh", ["-c", rendered], {
-    stdio: ["ignore", "pipe", "pipe"],
-    env: { ...process.env, ...env },
-  });
+    const handle = async (
+      event: Event,
+      { signal: handleAbortSignal = neverAbortSignal }: HandleOptions = {},
+    ): Promise<void> => {
+      if (disposeController.signal.aborted)
+        throw new Error("Shell agent disposed");
 
-  const onAbort = (): void => {
-    proc.kill("SIGTERM");
-  };
-  options?.signal?.addEventListener("abort", onAbort, { once: true });
+      const abortSignal = AbortSignal.any([
+        disposeController.signal,
+        handleAbortSignal,
+      ]);
+      const correlationId = `${event.id}`;
 
-  // Pipe stderr to logger (fire-and-forget)
-  stderr(proc)
-    .pipeThrough(lineStream())
-    .pipeTo(
-      new WritableStream({
-        write(line) {
-          logger.warn("stderr", { agent: id, line });
-        },
-      }),
-    )
-    .catch(() => {});
+      const rendered = renderTemplate(
+        shellScript,
+        event as unknown as Record<string, unknown>,
+      );
 
-  const lines = stdout(proc).pipeThrough(lineStream());
-  const reader = lines.getReader();
+      const proc = spawn("/bin/sh", ["-c", rendered], {
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env, ...env },
+      });
 
-  const exitPromise = new Promise<{
-    code: number | null;
-    signal: string | null;
-  }>((resolve) => {
-    proc.once("exit", (code, signal) => resolve({ code, signal }));
-  });
+      const onAbort = (): void => {
+        proc.kill("SIGTERM");
+      };
+      abortSignal.addEventListener("abort", onAbort, { once: true });
 
-  await send(`agent.${id}.start`, {
-    correlation_id: correlationId,
-    event_type: event.type,
-  });
+      // Pipe stderr to logger (fire-and-forget)
+      stderr(proc)
+        .pipeThrough(lineStream())
+        .pipeTo(
+          new WritableStream({
+            write(line) {
+              logger.warn("stderr", { agent: id, line });
+            },
+          }),
+        )
+        .catch(() => {});
 
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        const { code, signal } = await exitPromise;
-        if (code !== 0 && code !== null) {
-          await send(`agent.${id}.error`, {
-            correlation_id: correlationId,
-            code,
-            signal,
-          });
+      const lines = stdout(proc).pipeThrough(lineStream());
+      const reader = lines.getReader();
+
+      const exitPromise = new Promise<{
+        code: number | null;
+        signal: string | null;
+      }>((resolve) => {
+        proc.once("exit", (code, signal) => resolve({ code, signal }));
+      });
+
+      await send(`agent.${id}.start`, {
+        correlation_id: correlationId,
+        event_type: event.type,
+      });
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            const { code, signal } = await exitPromise;
+            if (code !== 0 && code !== null) {
+              await send(`agent.${id}.error`, {
+                correlation_id: correlationId,
+                code,
+                signal,
+              });
+            }
+            break;
+          }
+          await send(`agent.${id}.response`, { line: value });
         }
-        break;
+      } finally {
+        abortSignal.removeEventListener("abort", onAbort);
+        reader.releaseLock();
+        await send(`agent.${id}.end`, { correlation_id: correlationId });
       }
-      await send(`agent.${id}.response`, { line: value });
-    }
-  } finally {
-    options?.signal?.removeEventListener("abort", onAbort);
-    reader.releaseLock();
-    await send(`agent.${id}.end`, { correlation_id: correlationId });
-  }
-};
+    };
 
-export const shellAgentOf =
-  (config: ShellAgentConfig): AgentSetup =>
-  async (id, send) => {
-    let disposed = false;
+    const dispose = async (): Promise<void> => {
+      disposeController.abort(new Error("Dispose shell-agent"));
+    };
+
     return {
-      async handle(event, options) {
-        if (disposed) throw new Error("Shell agent disposed");
-        await handleEvent(id, send, config, event, options);
-      },
-      async [Symbol.asyncDispose]() {
-        disposed = true;
-      },
+      handle,
+      [Symbol.asyncDispose]: dispose,
     };
   };
+};

--- a/src/shell-agent.ts
+++ b/src/shell-agent.ts
@@ -82,19 +82,26 @@ export const shellAgentOf = (config: ShellAgentConfig): AgentSetup => {
             const { code, signal } = await exitPromise;
             if (code !== 0 && code !== null) {
               await send(`agent.${id}.error`, {
+                error: `Process exited unexpectedly (code ${code})`,
                 correlation_id: correlationId,
                 code,
                 signal,
               });
+            } else {
+              await send(`agent.${id}.end`, { correlation_id: correlationId });
             }
             break;
           }
-          await send(`agent.${id}.response`, { line: value });
+          await send(`agent.${id}.output`, { line: value });
         }
+      } catch (e) {
+        await send(`agent.${id}.error`, {
+          error: `${e}`,
+          correlation_id: correlationId,
+        });
       } finally {
         abortSignal.removeEventListener("abort", onAbort);
         reader.releaseLock();
-        await send(`agent.${id}.end`, { correlation_id: correlationId });
       }
     };
 

--- a/src/virtual-agent.test.ts
+++ b/src/virtual-agent.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { virtualAgentOf } from "./virtual-agent.ts";
 import type { Event } from "./lib/event.ts";
-import { collect } from "./lib/generator.ts";
+import type { SendFn } from "./agent.ts";
 
 const testEvent = (overrides: Partial<Event> = {}): Event => ({
   id: 1,
@@ -13,114 +13,65 @@ const testEvent = (overrides: Partial<Event> = {}): Event => ({
   ...overrides,
 });
 
+const noopSend: SendFn = async () => {};
+
 describe("virtualAgentOf", () => {
-  it("returns an agent with the configured properties", () => {
-    const agent = virtualAgentOf({
-      id: "my-agent",
-      listen: ["sys.reload"],
-      handler: () => {},
-    });
+  it("returns an AgentSetup that creates an agent", async () => {
+    const setup = virtualAgentOf(() => {});
+    const agent = await setup("my-agent", noopSend);
 
-    assert.equal(agent.id, "my-agent");
-    assert.deepEqual(agent.listen, ["sys.reload"]);
-    assert.equal(agent.ignoreSelf, true);
-    assert.equal(agent.disposed.aborted, false);
-  });
-
-  it("defaults ignoreSelf to true", () => {
-    const agent = virtualAgentOf({
-      id: "agent",
-      listen: [],
-      handler: () => {},
-    });
-    assert.equal(agent.ignoreSelf, true);
-  });
-
-  it("respects ignoreSelf config", () => {
-    const agent = virtualAgentOf({
-      id: "agent",
-      listen: [],
-      ignoreSelf: false,
-      handler: () => {},
-    });
-    assert.equal(agent.ignoreSelf, false);
-  });
-
-  it("validates id as slug", () => {
-    assert.throws(
-      () =>
-        virtualAgentOf({
-          id: "My Agent",
-          listen: [],
-          handler: () => {},
-        }),
-      /Invalid slug/,
-    );
+    assert.equal(typeof agent.handle, "function");
+    assert.equal(typeof agent[Symbol.asyncDispose], "function");
   });
 });
 
-describe("stream", () => {
-  it("calls handler with the event", () => {
+describe("handle", () => {
+  it("calls handler with send and event", async () => {
     const received: Event[] = [];
-    const agent = virtualAgentOf({
-      id: "handler-agent",
-      listen: ["*"],
-      handler: (event) => {
-        received.push(event);
-      },
+    const setup = virtualAgentOf((_send, event) => {
+      received.push(event);
     });
 
+    const agent = await setup("handler-agent", noopSend);
     const event = testEvent();
-    agent.stream(event);
+    await agent.handle(event);
+
     assert.equal(received.length, 1);
     assert.deepEqual(received[0], event);
   });
 
-  it("returns an empty stream", async () => {
-    const agent = virtualAgentOf({
-      id: "empty-agent",
-      listen: ["*"],
-      handler: () => {},
+  it("passes send function to handler", async () => {
+    const sent: Array<{ type: string; payload: unknown }> = [];
+    const fakeSend: SendFn = async (type, payload) => {
+      sent.push({ type, payload });
+    };
+
+    const setup = virtualAgentOf(async (send) => {
+      await send("test.response", { ok: true });
     });
 
-    const drafts = await collect(agent.stream(testEvent()));
-    assert.equal(drafts.length, 0);
+    const agent = await setup("sender-agent", fakeSend);
+    await agent.handle(testEvent());
+
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].type, "test.response");
   });
 
   it("throws after dispose", async () => {
-    const agent = virtualAgentOf({
-      id: "disposed-agent",
-      listen: ["*"],
-      handler: () => {},
-    });
+    const setup = virtualAgentOf(() => {});
+    const agent = await setup("disposed-agent", noopSend);
 
     await agent[Symbol.asyncDispose]();
-    assert.throws(() => agent.stream(testEvent()));
+    await assert.rejects(() => agent.handle(testEvent()), /disposed/i);
   });
 });
 
 describe("dispose", () => {
-  it("sets disposed signal to aborted", async () => {
-    const agent = virtualAgentOf({
-      id: "dispose-agent",
-      listen: ["*"],
-      handler: () => {},
-    });
-
-    assert.equal(agent.disposed.aborted, false);
-    await agent[Symbol.asyncDispose]();
-    assert.equal(agent.disposed.aborted, true);
-  });
-
   it("is idempotent", async () => {
-    const agent = virtualAgentOf({
-      id: "dispose-agent",
-      listen: ["*"],
-      handler: () => {},
-    });
+    const setup = virtualAgentOf(() => {});
+    const agent = await setup("dispose-agent", noopSend);
 
     await agent[Symbol.asyncDispose]();
-    await agent[Symbol.asyncDispose]();
-    assert.equal(agent.disposed.aborted, true);
+    await agent[Symbol.asyncDispose](); // Should not throw
   });
 });

--- a/src/virtual-agent.ts
+++ b/src/virtual-agent.ts
@@ -17,7 +17,7 @@ export const virtualAgentOf =
     const handle = async (
       event: Event,
       { signal: abortHandleSignal = neverAbortSignal }: HandleOptions = {},
-    ) => {
+    ): Promise<void> => {
       if (disposedController.signal.aborted)
         throw new Error("Agent is disposed");
       const abortSignal = AbortSignal.any([

--- a/src/virtual-agent.ts
+++ b/src/virtual-agent.ts
@@ -4,20 +4,35 @@ import type { AgentSetup, HandleOptions, SendFn } from "./agent.ts";
 export type AgentHandler = (
   send: SendFn,
   event: Event,
-  options?: HandleOptions,
+  options: HandleOptions,
 ) => void | Promise<void>;
+
+const neverAbortSignal = new AbortController().signal;
 
 export const virtualAgentOf =
   (handler: AgentHandler): AgentSetup =>
   async (_id, send) => {
-    let disposed = false;
+    const disposedController = new AbortController();
+
+    const handle = async (
+      event: Event,
+      { signal: abortHandleSignal = neverAbortSignal }: HandleOptions = {},
+    ) => {
+      if (disposedController.signal.aborted)
+        throw new Error("Agent is disposed");
+      const abortSignal = AbortSignal.any([
+        disposedController.signal,
+        abortHandleSignal,
+      ]);
+      await handler(send, event, { signal: abortSignal });
+    };
+
+    const dispose = async (): Promise<void> => {
+      disposedController.abort(new Error("Abort virtual-agent"));
+    };
+
     return {
-      async handle(event, options) {
-        if (disposed) throw new Error("Agent is disposed");
-        await handler(send, event, options);
-      },
-      async [Symbol.asyncDispose]() {
-        disposed = true;
-      },
+      handle,
+      [Symbol.asyncDispose]: dispose,
     };
   };

--- a/src/virtual-agent.ts
+++ b/src/virtual-agent.ts
@@ -1,43 +1,23 @@
-import type { Agent } from "./agent.ts";
 import type { Event } from "./lib/event.ts";
-import type { EventDraft } from "./lib/event.ts";
-import { parseSlug } from "./lib/slug.ts";
+import type { AgentSetup, HandleOptions, SendFn } from "./agent.ts";
 
-export type VirtualAgentHandler = (event: Event) => void | Promise<void>;
+export type AgentHandler = (
+  send: SendFn,
+  event: Event,
+  options?: HandleOptions,
+) => void | Promise<void>;
 
-export type VirtualAgentConfig = {
-  id: string;
-  listen: string[];
-  ignoreSelf?: boolean;
-  handler: VirtualAgentHandler;
-};
-
-export const virtualAgentOf = (config: VirtualAgentConfig): Agent => {
-  const { listen, ignoreSelf = true, handler } = config;
-  const id = parseSlug(config.id);
-  const abortController = new AbortController();
-
-  const stream = (event: Event): ReadableStream<EventDraft> => {
-    abortController.signal.throwIfAborted();
-    return new ReadableStream<EventDraft>({
-      async start(controller) {
-        await handler(event);
-        controller.close();
+export const virtualAgentOf =
+  (handler: AgentHandler): AgentSetup =>
+  async (_id, send) => {
+    let disposed = false;
+    return {
+      async handle(event, options) {
+        if (disposed) throw new Error("Agent is disposed");
+        await handler(send, event, options);
       },
-    });
+      async [Symbol.asyncDispose]() {
+        disposed = true;
+      },
+    };
   };
-
-  const asyncDispose = async (): Promise<void> => {
-    if (abortController.signal.aborted) return;
-    abortController.abort(new Error("Virtual agent disposed"));
-  };
-
-  return {
-    id,
-    listen,
-    ignoreSelf,
-    stream,
-    disposed: abortController.signal,
-    [Symbol.asyncDispose]: asyncDispose,
-  };
-};


### PR DESCRIPTION
Fixes https://github.com/gordonbrander/busytown-pi/issues/44

## Summary

- Replaces the stream-based agent interface (`stream(event): ReadableStream<EventDraft>`) with an effectful interface (`handle(event): Promise<void>`). Agents receive a `send` function at construction time.
- Introduces `AgentSetup = (id, send) => Promise<Agent>` factory pattern
- System owns id, listen, ignoreSelf, and other system-level concerns.`
- Simplifies all agent implementations (pi, pi-rpc, shell, virtual) by ~290 lines net, removing `ReadableStream` machinery in favor of direct `send()` calls

## Test plan

- [x] `node --experimental-strip-types --test src/agent-system.test.ts` — spawn, dispose, event routing, ignoreSelf, send-based event emission
- [x] `node --experimental-strip-types --test src/virtual-agent.test.ts` — setup, handle, send passthrough, dispose guard
- [x] `node --experimental-strip-types --test src/shell-agent.test.ts` — stdout lines, templates, error codes, dispose guard
- [x] `node --experimental-strip-types --test src/lib/*.test.ts` — no regressions in shared utilities
- [x] Manual: `node --experimental-strip-types src/cli.ts start` + push an event, verify agents process it