### PR TITLE
Support agent.<id>.new_session events

### DIFF
--- a/src/lib/pi-rpc-commands.ts
+++ b/src/lib/pi-rpc-commands.ts
@@ -1,0 +1,36 @@
+import type { AgentSessionEvent as PiAgentSessionEvent } from "@mariozechner/pi-coding-agent";
+
+/**
+ * A Pi RPC `prompt` command — what gets written to the Pi process stdin to
+ * start an agent run.
+ */
+export type PromptCommand = { type: "prompt"; message: string };
+export type AbortCommand = { type: "abort" };
+export type CompactCommand = { type: "compact" };
+export type NewSessionCommand = { type: "new_session" };
+export type PiRpcCommand =
+  | PromptCommand
+  | AbortCommand
+  | CompactCommand
+  | NewSessionCommand;
+
+/**
+ * A synchronous RPC response to a command we sent. The full `RpcResponse`
+ * type isn't exported from `@mariozechner/pi-coding-agent`, so we describe
+ * just the discriminator + the fields we read.
+ */
+export type PiRpcResponse = {
+  type: "response";
+  command: string;
+  success: boolean;
+  data?: unknown;
+};
+
+/**
+ * A line emitted on Pi RPC stdout — either a streamed session event or a
+ * synchronous RPC response.
+ */
+export type PiRpcStdoutLine = PiAgentSessionEvent | PiRpcResponse;
+
+export const isPiRpcResponse = (line: PiRpcStdoutLine): line is PiRpcResponse =>
+  line.type === "response";

--- a/src/pi-rpc-agent.ts
+++ b/src/pi-rpc-agent.ts
@@ -7,13 +7,14 @@ import {
   stdout,
   writeJsonLine,
 } from "./lib/web-stream.ts";
-import {
-  fromPiAgentSessionEvent,
-  type PiAgentSessionEvent,
-} from "./lib/agent-session-event.ts";
+import { fromPiAgentSessionEvent } from "./lib/agent-session-event.ts";
 import { type Event } from "./lib/event.ts";
 import { loggerOf } from "./lib/json-logger.ts";
-import type { PiRpcCommand } from "./pi-rpc-commands.ts";
+import {
+  isPiRpcResponse,
+  type PiRpcCommand,
+  type PiRpcStdoutLine,
+} from "./lib/pi-rpc-commands.ts";
 import type { AgentSetup, Agent } from "./agent.ts";
 
 const logger = loggerOf({ source: "pi-rpc-agent.ts" });
@@ -93,8 +94,9 @@ export const piRpcAgentSetupOf = (config: PiRpcAgentConfig): AgentSetup => {
       }
     };
 
-    // Convert stdout to a web ReadableStream of JSONL lines
-    const output: ReadableStream<PiAgentSessionEvent> = stdout(proc)
+    // Convert stdout to a web ReadableStream of JSONL lines. The stream
+    // interleaves streamed session events and synchronous RPC responses.
+    const output: ReadableStream<PiRpcStdoutLine> = stdout(proc)
       .pipeThrough(lineStream())
       .pipeThrough(mapStream(JSON.parse));
 
@@ -132,10 +134,13 @@ export const piRpcAgentSetupOf = (config: PiRpcAgentConfig): AgentSetup => {
         });
 
         const isCompact = event.type === `agent.${id}.compact`;
+        const isNewSession = event.type === `agent.${id}.new_session`;
 
         try {
           if (isCompact) {
             await sendCommand({ type: "compact" });
+          } else if (isNewSession) {
+            await sendCommand({ type: "new_session" });
           } else {
             await sendEventPromptCommand(event);
           }
@@ -146,14 +151,25 @@ export const piRpcAgentSetupOf = (config: PiRpcAgentConfig): AgentSetup => {
               break;
             }
 
-            const sessionEvent = fromPiAgentSessionEvent(value, correlationId);
-            if (sessionEvent) {
-              await send(`agent.${id}.message`, sessionEvent);
+            // RPC responses can interleave with session events; only forward
+            // session events to listeners.
+            if (!isPiRpcResponse(value)) {
+              const sessionEvent = fromPiAgentSessionEvent(
+                value,
+                correlationId,
+              );
+              if (sessionEvent) {
+                await send(`agent.${id}.message`, sessionEvent);
+              }
             }
 
+            // `new_session` doesn't emit streaming events — its `response`
+            // line is the only signal that the reset is complete.
             const isDone = isCompact
               ? value.type === "compaction_end"
-              : value.type === "agent_end";
+              : isNewSession
+                ? isPiRpcResponse(value) && value.command === "new_session"
+                : value.type === "agent_end";
 
             if (isDone) {
               await send(`agent.${id}.end`, {
@@ -203,7 +219,7 @@ export const piRpcAgentOf = (config: PiRpcAgentFactoryConfig): Agent => {
   const { id, listen, ignoreSelf, ...setupConfig } = config;
   return {
     id,
-    listen: [...listen, `agent.${id}.compact`],
+    listen: [...listen, `agent.${id}.compact`, `agent.${id}.new_session`],
     ignoreSelf,
     setup: piRpcAgentSetupOf(setupConfig),
   };

--- a/src/pi-rpc-commands.ts
+++ b/src/pi-rpc-commands.ts
@@ -1,8 +1,0 @@
-/**
- * A Pi RPC `prompt` command — what gets written to the Pi process stdin to
- * start an agent run.
- */
-export type PromptCommand = { type: "prompt"; message: string };
-export type AbortCommand = { type: "abort" };
-export type CompactCommand = { type: "compact" };
-export type PiRpcCommand = PromptCommand | AbortCommand | CompactCommand;


### PR DESCRIPTION
Allows us to reset agent session via pushing an event.

Fixes #48 