### PR TITLE
Include LLM errors in simplified messages

### DIFF
--- a/docs/simplified-llm-events.md
+++ b/docs/simplified-llm-events.md
@@ -140,24 +140,24 @@ model omits.
 
 #### Event mapping
 
-| Simplified Event       | Pi Event(s)                             | Notes                                                           |
-| ---------------------- | --------------------------------------- | --------------------------------------------------------------- |
-| `user_message`         | _(implicit — event passed to `send()`)_ | Simplified makes this explicit with an `id` → `correlation_id`  |
-| `agent_start`          | `agent_start`                           | Same                                                            |
-| `agent_end`            | `agent_end`                             | Both carry `messages`; simplified adds total token counts       |
-| `turn_start`           | `turn_start`                            | Pi adds `turnIndex`                                             |
-| `turn_end`             | `turn_end`                              | Simplified carries tokens; Pi carries `message` + `toolResults` |
-| `thinking_start`       | `message_update { thinking_start }`     | Same content, different envelope                                |
-| `thinking_end`         | `message_update { thinking_end }`       | Both carry full assembled text                                  |
-| `text_start`           | `message_update { text_start }`         | Same                                                            |
-| `text_end`             | `message_update { text_end }`           | Both carry full assembled text                                  |
-| `toolcall_start`       | `message_update { toolcall_start }`     | Simplified includes `tool_call_id` and `name` upfront           |
-| `toolcall_end`         | `message_update { toolcall_end }`       | Both carry name + args; Pi nests under `toolCall` object        |
-| `tool_execution_end`   | `tool_execution_end`                    | Both carry `tool_call_id`, output/error                         |
-| `error`                | `message_update { error }`              | Pi scopes to message; simplified is a top-level turn event      |
-| `compaction_start/end` | `compaction_start/end`                  | Same fields                                                     |
-| `auto_retry_start/end` | `auto_retry_start/end`                  | Same fields                                                     |
+| Simplified Event       | Pi Event(s)                                                                                              | Notes                                                                                               |
+| ---------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `user_message`         | _(implicit — event passed to `send()`)_                                                                  | Simplified makes this explicit with an `id` → `correlation_id`                                      |
+| `agent_start`          | `agent_start`                                                                                            | Same                                                                                                |
+| `agent_end`            | `agent_end`                                                                                              | Both carry `messages`; simplified adds total token counts                                           |
+| `turn_start`           | `turn_start`                                                                                             | Pi adds `turnIndex`                                                                                 |
+| `turn_end`             | `turn_end`                                                                                               | Simplified carries tokens; Pi carries `message` + `toolResults`                                     |
+| `thinking_start`       | `message_update { thinking_start }`                                                                      | Same content, different envelope                                                                    |
+| `thinking_end`         | `message_update { thinking_end }`                                                                        | Both carry full assembled text                                                                      |
+| `text_start`           | `message_update { text_start }`                                                                          | Same                                                                                                |
+| `text_end`             | `message_update { text_end }`                                                                            | Both carry full assembled text                                                                      |
+| `toolcall_start`       | `message_update { toolcall_start }`                                                                      | Simplified includes `tool_call_id` and `name` upfront                                               |
+| `toolcall_end`         | `message_update { toolcall_end }`                                                                        | Both carry name + args; Pi nests under `toolCall` object                                            |
+| `tool_execution_end`   | `tool_execution_end`                                                                                     | Both carry `tool_call_id`, output/error                                                             |
+| `error`                | `message_end { message.stopReason: "error" \| "aborted" }` (also `message_update { error }` defensively) | Pi reports failed/aborted LLM calls by setting `stopReason` and `errorMessage` on the final message |
+| `compaction_start/end` | `compaction_start/end`                                                                                   | Same fields                                                                                         |
+| `auto_retry_start/end` | `auto_retry_start/end`                                                                                   | Same fields                                                                                         |
 
-Pi events with no simplified equivalent: `message_start`, `message_end`,
-`message_update { start }`, `message_update { done }`, all `*_delta` events,
-`tool_execution_start`, and `tool_execution_update`.
+Pi events with no simplified equivalent: `message_start`, successful
+`message_end`, `message_update { start }`, `message_update { done }`, all
+`*_delta` events, `tool_execution_start`, and `tool_execution_update`.

--- a/src/lib/agent-session-event.test.ts
+++ b/src/lib/agent-session-event.test.ts
@@ -7,9 +7,12 @@ import { fromPiAgentSessionEvent } from "./agent-session-event.ts";
 const pi = (obj: object): PiAgentSessionEvent => obj as PiAgentSessionEvent;
 
 // Placeholder values for Pi fields that our mapping strips.
-const AGENT_MSG = { role: "assistant", content: [] };
+const AGENT_MSG = { role: "assistant", content: [], stopReason: "stop" };
 const TOOL_RESULTS = [{ role: "toolResult" }];
 const PARTIAL = { role: "assistant", content: [] };
+
+/** Clone AGENT_MSG with overrides — used for message_end error tests. */
+const assistantMsg = (overrides: object) => ({ ...AGENT_MSG, ...overrides });
 
 const CID = "msg_42";
 
@@ -67,7 +70,7 @@ describe("fromPiAgentSessionEvent", () => {
     });
   });
 
-  describe("message envelope events are dropped", () => {
+  describe("message envelope events", () => {
     it("returns undefined for message_start", () => {
       assert.equal(
         fromPiAgentSessionEvent(
@@ -78,10 +81,95 @@ describe("fromPiAgentSessionEvent", () => {
       );
     });
 
-    it("returns undefined for message_end", () => {
+    it("returns undefined for successful message_end", () => {
       assert.equal(
         fromPiAgentSessionEvent(
           pi({ type: "message_end", message: AGENT_MSG }),
+          CID,
+        ),
+        undefined,
+      );
+    });
+  });
+
+  describe("message_end with failed/aborted assistant message", () => {
+    it("maps stopReason: error with errorMessage to simplified error event", () => {
+      assert.deepEqual(
+        fromPiAgentSessionEvent(
+          pi({
+            type: "message_end",
+            message: assistantMsg({
+              stopReason: "error",
+              errorMessage: '400 {"type":"error", … plan limits …}',
+            }),
+          }),
+          CID,
+        ),
+        {
+          type: "error",
+          correlation_id: CID,
+          message: '400 {"type":"error", … plan limits …}',
+          code: "error",
+        },
+      );
+    });
+
+    it("maps stopReason: aborted without errorMessage, falling back to stopReason", () => {
+      assert.deepEqual(
+        fromPiAgentSessionEvent(
+          pi({
+            type: "message_end",
+            message: assistantMsg({ stopReason: "aborted" }),
+          }),
+          CID,
+        ),
+        {
+          type: "error",
+          correlation_id: CID,
+          message: "aborted",
+          code: "aborted",
+        },
+      );
+    });
+
+    it("returns undefined for assistant message with stopReason: stop", () => {
+      assert.equal(
+        fromPiAgentSessionEvent(
+          pi({
+            type: "message_end",
+            message: assistantMsg({ stopReason: "stop" }),
+          }),
+          CID,
+        ),
+        undefined,
+      );
+    });
+
+    it("returns undefined for user messages (no stopReason)", () => {
+      assert.equal(
+        fromPiAgentSessionEvent(
+          pi({
+            type: "message_end",
+            message: { role: "user", content: "hello" },
+          }),
+          CID,
+        ),
+        undefined,
+      );
+    });
+
+    it("returns undefined for toolResult messages", () => {
+      assert.equal(
+        fromPiAgentSessionEvent(
+          pi({
+            type: "message_end",
+            message: {
+              role: "toolResult",
+              toolCallId: "call_1",
+              content: "ok",
+              isError: false,
+            },
+          }),
           CID,
         ),
         undefined,
@@ -263,13 +351,18 @@ describe("fromPiAgentSessionEvent", () => {
   });
 
   describe("error (flattened from message_update)", () => {
-    it("maps error with reason as message", () => {
+    it("maps error with reason as both message and code", () => {
       assert.deepEqual(
         fromPiAgentSessionEvent(
           update({ type: "error", reason: "aborted", error: AGENT_MSG }),
           CID,
         ),
-        { type: "error", correlation_id: CID, message: "aborted" },
+        {
+          type: "error",
+          correlation_id: CID,
+          message: "aborted",
+          code: "aborted",
+        },
       );
     });
   });

--- a/src/lib/agent-session-event.ts
+++ b/src/lib/agent-session-event.ts
@@ -96,7 +96,7 @@ export type AgentError = {
   type: "error";
   correlation_id: string;
   message: string;
-  code?: string;
+  code?: "error" | "aborted";
 };
 
 export type CompactionStart = {
@@ -248,10 +248,26 @@ export const fromPiAgentSessionEvent = (
         finalError: event.finalError,
       };
 
-    // message_start, message_end — envelope events, no simplified equivalent
+    // message_start — envelope event, no simplified equivalent
     case "message_start":
-    case "message_end":
       return undefined;
+
+    // message_end — drop on success, surface as `error` on failed/aborted turns.
+    // pi-agent-core's agent-loop delivers LLM errors only via message_end
+    // carrying an AssistantMessage with stopReason: "error" | "aborted".
+    case "message_end": {
+      const msg = event.message;
+      if (msg.role !== "assistant") return undefined;
+      if (msg.stopReason !== "error" && msg.stopReason !== "aborted") {
+        return undefined;
+      }
+      return {
+        type: "error",
+        correlation_id: correlationId,
+        message: msg.errorMessage ?? msg.stopReason,
+        code: msg.stopReason,
+      };
+    }
   }
 };
 
@@ -321,6 +337,7 @@ const fromAssistantMessageEvent = (
         type: "error",
         correlation_id: correlationId,
         message: event.reason,
+        code: event.reason,
       };
 
     // Deltas and envelope sub-events — no simplified equivalent


### PR DESCRIPTION
Catches errors generated by API failures.