### PR TITLE
fix: pidfile path mismatch preventing daemon start

### DIFF
--- a/src/pidfile.ts
+++ b/src/pidfile.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 const PIDFILE_NAME = "busytown.pid";
 
 export const pidfilePath = (projectRoot: string): string =>
-  path.join(projectRoot, ".busytown", PIDFILE_NAME);
+  path.join(projectRoot, ".pi", "busytown", PIDFILE_NAME);
 
 /** Write current process PID to the pidfile. Creates .busytown dir if needed. */
 export const writePidfile = (projectRoot: string): void => {


### PR DESCRIPTION
### Summary

- Fix `pidfilePath` in `pidfile.ts` to use `.pi/busytown/` instead of `.busytown/`, matching the directory convention used by the rest of the codebase (daemon logs, SQLite database)
- The mismatch caused stale pidfiles to go undetected, and could block daemon starts when the stale PID was coincidentally reused by an unrelated process

### Test plan

- [x] `busytown start` launches the daemon and writes pidfile to `.pi/busytown/busytown.pid`
- [x] `busytown status` correctly detects the running daemon
- [x] `busytown stop` followed by `busytown start` works without manual cleanup
- [x] Stale pidfile (dead process) is cleaned up automatically by `getDaemonStatus`