### PR TITLE
Pass event as context key to shell template render

### DIFF
--- a/src/shell-agent.test.ts
+++ b/src/shell-agent.test.ts
@@ -63,7 +63,7 @@ describe("handle", () => {
     "templates event fields into the shell script",
     { timeout: 2000 },
     async () => {
-      const setup = shellAgentSetupOf({ shellScript: "echo {{type}}" });
+      const setup = shellAgentSetupOf({ shellScript: "echo {{event.type}}" });
       const { sent, send } = collectSent();
       const agent = await setup("template-agent", send);
 
@@ -79,7 +79,7 @@ describe("handle", () => {
 
   it("templates nested payload fields", { timeout: 2000 }, async () => {
     const setup = shellAgentSetupOf({
-      shellScript: "echo {{{payload.message}}}",
+      shellScript: "echo {{{event.payload.message}}}",
     });
     const { sent, send } = collectSent();
     const agent = await setup("nested-agent", send);

--- a/src/shell-agent.ts
+++ b/src/shell-agent.ts
@@ -34,10 +34,11 @@ export const shellAgentSetupOf = (config: ShellAgentConfig): AgentSetup => {
       ]);
       const correlationId = `${event.id}`;
 
-      const rendered = renderTemplate(
-        shellScript,
-        event as unknown as Record<string, unknown>,
-      );
+      // Render `{{placeholders}}` in shell script, making event
+      // available to the script.
+      const rendered = renderTemplate(shellScript, {
+        event,
+      });
 
       const proc = spawn("/bin/sh", ["-c", rendered], {
         stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
Fixes a bug where older shell agents weren't finding the data they needed, because we were previously passing event as a key, rather than as the context.

Either approach is technically correct, but the old approach is better because it allows us to add other template context fields later.