### PR TITLE
Add epoc and compact-db

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,8 +11,8 @@ import {
   getClaimant,
   getEventsSince,
   getOrOpenDb,
+  setEpoch,
   pushEvent,
-  seekToTail,
 } from "./event-queue.ts";
 import { listAgentPaths } from "./agents/file-agent-loader.ts";
 import {
@@ -493,7 +493,7 @@ const epochCommand = defineCommand({
   run: ({ args }) => {
     const db = resolveDb(args.dir, args.db);
     try {
-      const result = seekToTail(db);
+      const result = setEpoch(db);
       console.log(JSON.stringify(result));
     } finally {
       db.close();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,10 +7,12 @@ import { fileURLToPath } from "node:url";
 import { defineCommand, runMain } from "citty";
 import {
   claimEvent,
+  compactEvents,
   getClaimant,
   getEventsSince,
   getOrOpenDb,
   pushEvent,
+  seekToTail,
 } from "./event-queue.ts";
 import { listAgentPaths } from "./agents/file-agent-loader.ts";
 import {
@@ -479,6 +481,55 @@ const reloadCommand = defineCommand({
   },
 });
 
+const epochCommand = defineCommand({
+  meta: {
+    name: "epoch",
+    description:
+      "Push a sys.epoch event and advance all agent cursors to its id",
+  },
+  args: {
+    ...globalArgs,
+  },
+  run: ({ args }) => {
+    const db = resolveDb(args.dir, args.db);
+    try {
+      const result = seekToTail(db);
+      console.log(JSON.stringify(result));
+    } finally {
+      db.close();
+    }
+  },
+});
+
+const compactDbCommand = defineCommand({
+  meta: {
+    name: "compact-db",
+    description: "Delete events already processed by all agents",
+  },
+  args: {
+    ...globalArgs,
+    "warn-threshold": {
+      type: "string",
+      description: "Warn for agents more than N events behind (default: 100)",
+    },
+  },
+  run: ({ args }) => {
+    const db = resolveDb(args.dir, args.db);
+    try {
+      const raw = args["warn-threshold"];
+      const parsed = raw ? parseInt(raw, 10) : 100;
+      const threshold = isNaN(parsed) ? 100 : parsed;
+      const result = compactEvents(db, threshold);
+      for (const { agent_id, behind } of result.laggingAgents) {
+        console.warn(`warning: agent "${agent_id}" is ${behind} events behind`);
+      }
+      console.log(JSON.stringify(result));
+    } finally {
+      db.close();
+    }
+  },
+});
+
 // -- Main command ------------------------------------------------------------
 
 const main = defineCommand({
@@ -497,6 +548,8 @@ const main = defineCommand({
     claim: claimCommand,
     "check-claim": checkClaimCommand,
     reload: reloadCommand,
+    epoch: epochCommand,
+    "compact-db": compactDbCommand,
   },
 });
 

--- a/src/event-queue.test.ts
+++ b/src/event-queue.test.ts
@@ -3,15 +3,19 @@ import assert from "node:assert/strict";
 import { DatabaseSync } from "node:sqlite";
 import {
   claimEvent,
+  compactEvents,
+  getAllCursors,
   getClaimant,
   getCursor,
   getEventsSince,
+  getLatestEventId,
   getNextEvent,
   getOrCreateCursor,
   openDb,
   pollEvents,
   pullNextMatchingEvent,
   pushEvent,
+  seekToTail,
   updateCursor,
 } from "./event-queue.ts";
 
@@ -378,6 +382,163 @@ describe("claimEvent / getClaimant", () => {
 
     const claimant = getClaimant(db, event.id);
     assert.equal(claimant, undefined);
+    db.close();
+  });
+});
+
+describe("getLatestEventId", () => {
+  it("returns 0 for an empty db", () => {
+    const db = createTestDb();
+    assert.equal(getLatestEventId(db), 0);
+    db.close();
+  });
+
+  it("returns the max event id", () => {
+    const db = createTestDb();
+    pushEvent(db, "w", "a");
+    pushEvent(db, "w", "b");
+    const last = pushEvent(db, "w", "c");
+    assert.equal(getLatestEventId(db), last.id);
+    db.close();
+  });
+});
+
+describe("getAllCursors", () => {
+  it("returns an empty array when no cursors exist", () => {
+    const db = createTestDb();
+    assert.deepEqual(getAllCursors(db), []);
+    db.close();
+  });
+
+  it("returns all cursor rows sorted by agent_id", () => {
+    const db = createTestDb();
+    updateCursor(db, "beta", 10);
+    updateCursor(db, "alpha", 5);
+    const cursors = getAllCursors(db);
+    assert.equal(cursors.length, 2);
+    assert.equal(cursors[0].agent_id, "alpha");
+    assert.equal(cursors[0].since, 5);
+    assert.equal(cursors[1].agent_id, "beta");
+    assert.equal(cursors[1].since, 10);
+    db.close();
+  });
+});
+
+describe("seekToTail", () => {
+  it("pushes a sys.epoch event and advances all cursors to its id", () => {
+    const db = createTestDb();
+    pushEvent(db, "w", "a");
+    pushEvent(db, "w", "b");
+    updateCursor(db, "agent-1", 1);
+    updateCursor(db, "agent-2", 1);
+
+    const { event, advancedAgentIds } = seekToTail(db);
+
+    assert.equal(event.type, "sys.epoch");
+    assert.equal(event.agent_id, "sys");
+    assert.deepEqual(advancedAgentIds.sort(), ["agent-1", "agent-2"]);
+    assert.equal(getCursor(db, "agent-1"), event.id);
+    assert.equal(getCursor(db, "agent-2"), event.id);
+    db.close();
+  });
+
+  it("pushes the event even when no cursors exist", () => {
+    const db = createTestDb();
+    const { event, advancedAgentIds } = seekToTail(db);
+    assert.equal(event.type, "sys.epoch");
+    assert.deepEqual(advancedAgentIds, []);
+    assert.equal(getLatestEventId(db), event.id);
+    db.close();
+  });
+});
+
+describe("compactEvents", () => {
+  it("deletes events with id strictly less than the minimum cursor", () => {
+    const db = createTestDb();
+    const events = [
+      pushEvent(db, "w", "a"),
+      pushEvent(db, "w", "b"),
+      pushEvent(db, "w", "c"),
+      pushEvent(db, "w", "d"),
+    ];
+    updateCursor(db, "fast", events[3].id);
+    updateCursor(db, "slow", events[2].id);
+
+    const result = compactEvents(db);
+
+    assert.equal(result.minCursor, events[2].id);
+    assert.equal(result.deletedEvents, 2);
+    assert.equal(result.latestId, events[3].id);
+    const remaining = getEventsSince(db, { sinceId: 0, limit: 100 });
+    assert.deepEqual(
+      remaining.map((e) => e.id),
+      [events[2].id, events[3].id],
+    );
+    db.close();
+  });
+
+  it("is a no-op when no cursors exist", () => {
+    const db = createTestDb();
+    pushEvent(db, "w", "a");
+    pushEvent(db, "w", "b");
+
+    const result = compactEvents(db);
+
+    assert.equal(result.deletedEvents, 0);
+    assert.equal(result.deletedClaims, 0);
+    assert.equal(result.minCursor, 0);
+    assert.deepEqual(result.laggingAgents, []);
+    assert.equal(getEventsSince(db, { sinceId: 0, limit: 100 }).length, 2);
+    db.close();
+  });
+
+  it("also deletes claims for removed events", () => {
+    const db = createTestDb();
+    const e1 = pushEvent(db, "w", "a");
+    const e2 = pushEvent(db, "w", "b");
+    const e3 = pushEvent(db, "w", "c");
+    claimEvent(db, "claimer", e1.id);
+    claimEvent(db, "claimer", e2.id);
+    updateCursor(db, "agent", e3.id);
+
+    const result = compactEvents(db);
+
+    assert.ok(result.deletedClaims >= 2);
+    assert.equal(getClaimant(db, e1.id), undefined);
+    assert.equal(getClaimant(db, e2.id), undefined);
+    db.close();
+  });
+
+  it("warns per agent whose cursor is more than threshold behind tail", () => {
+    const db = createTestDb();
+    for (let i = 0; i < 150; i++) {
+      pushEvent(db, "w", "tick");
+    }
+    const latest = getLatestEventId(db);
+    updateCursor(db, "slow", 10);
+    updateCursor(db, "medium", latest - 50);
+    updateCursor(db, "fast", latest);
+
+    const result = compactEvents(db, 100);
+
+    const ids = result.laggingAgents.map((a) => a.agent_id);
+    assert.deepEqual(ids, ["slow"]);
+    assert.equal(result.laggingAgents[0].behind, latest - 10);
+    db.close();
+  });
+
+  it("produces no warnings when all cursors are within threshold", () => {
+    const db = createTestDb();
+    for (let i = 0; i < 50; i++) {
+      pushEvent(db, "w", "tick");
+    }
+    const latest = getLatestEventId(db);
+    updateCursor(db, "a", latest - 5);
+    updateCursor(db, "b", latest);
+
+    const result = compactEvents(db, 100);
+
+    assert.deepEqual(result.laggingAgents, []);
     db.close();
   });
 });

--- a/src/event-queue.test.ts
+++ b/src/event-queue.test.ts
@@ -14,8 +14,8 @@ import {
   openDb,
   pollEvents,
   pullNextMatchingEvent,
+  setEpoch,
   pushEvent,
-  seekToTail,
   updateCursor,
 } from "./event-queue.ts";
 
@@ -424,7 +424,7 @@ describe("getAllCursors", () => {
   });
 });
 
-describe("seekToTail", () => {
+describe("setEpoch", () => {
   it("pushes a sys.epoch event and advances all cursors to its id", () => {
     const db = createTestDb();
     pushEvent(db, "w", "a");
@@ -432,7 +432,7 @@ describe("seekToTail", () => {
     updateCursor(db, "agent-1", 1);
     updateCursor(db, "agent-2", 1);
 
-    const { event, advancedAgentIds } = seekToTail(db);
+    const { event, advancedAgentIds } = setEpoch(db);
 
     assert.equal(event.type, "sys.epoch");
     assert.equal(event.agent_id, "sys");
@@ -444,7 +444,7 @@ describe("seekToTail", () => {
 
   it("pushes the event even when no cursors exist", () => {
     const db = createTestDb();
-    const { event, advancedAgentIds } = seekToTail(db);
+    const { event, advancedAgentIds } = setEpoch(db);
     assert.equal(event.type, "sys.epoch");
     assert.deepEqual(advancedAgentIds, []);
     assert.equal(getLatestEventId(db), event.id);

--- a/src/event-queue.ts
+++ b/src/event-queue.ts
@@ -277,3 +277,116 @@ export const getClaimant = (
     .prepare(`SELECT agent_id, claimed_at FROM claims WHERE event_id = ?`)
     .get(eventId) as { agent_id: string; claimed_at: number } | undefined;
 };
+
+export const getLatestEventId = (db: DatabaseSync): number => {
+  const row = db.prepare(`SELECT MAX(id) AS id FROM events`).get() as
+    | { id: number | null }
+    | undefined;
+  return row?.id ?? 0;
+};
+
+export type CursorRow = {
+  agent_id: string;
+  since: number;
+  timestamp: number;
+};
+
+export const getAllCursors = (db: DatabaseSync): CursorRow[] => {
+  return db
+    .prepare(
+      `SELECT agent_id, since, timestamp FROM agent_cursors ORDER BY agent_id ASC`,
+    )
+    .all() as CursorRow[];
+};
+
+/**
+ * Push a sys.epoch event and advance every existing agent cursor to that
+ * event's id. Atomic.
+ */
+export const seekToTail = (
+  db: DatabaseSync,
+): { event: Event; advancedAgentIds: string[] } => {
+  db.exec("BEGIN");
+  try {
+    const event = pushEvent(db, "sys", "sys.epoch", {});
+    const cursors = getAllCursors(db);
+    const update = db.prepare(
+      `UPDATE agent_cursors SET since = ?, timestamp = unixepoch() WHERE agent_id = ?`,
+    );
+    for (const cursor of cursors) {
+      update.run(event.id, cursor.agent_id);
+    }
+    db.exec("COMMIT");
+    return {
+      event,
+      advancedAgentIds: cursors.map((c) => c.agent_id),
+    };
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+};
+
+export type CompactResult = {
+  deletedEvents: number;
+  deletedClaims: number;
+  minCursor: number;
+  latestId: number;
+  laggingAgents: Array<{ agent_id: string; behind: number }>;
+};
+
+/**
+ * Delete events with id < min(agent cursor). Also deletes claims for those
+ * events (claims has no FK cascade). If no cursors exist, no-op.
+ * Returns per-agent warnings when `latestId - cursor.since > warnThreshold`.
+ */
+export const compactEvents = (
+  db: DatabaseSync,
+  warnThreshold: number = 100,
+): CompactResult => {
+  db.exec("BEGIN");
+  try {
+    const cursors = getAllCursors(db);
+    const latestId = getLatestEventId(db);
+
+    const laggingAgents = cursors
+      .map((c) => ({ agent_id: c.agent_id, behind: latestId - c.since }))
+      .filter((c) => c.behind > warnThreshold)
+      .sort((a, b) => b.behind - a.behind);
+
+    if (cursors.length === 0) {
+      db.exec("COMMIT");
+      return {
+        deletedEvents: 0,
+        deletedClaims: 0,
+        minCursor: 0,
+        latestId,
+        laggingAgents,
+      };
+    }
+
+    const minCursor = cursors.reduce(
+      (min, c) => (c.since < min ? c.since : min),
+      cursors[0].since,
+    );
+
+    const deletedClaims = db
+      .prepare(`DELETE FROM claims WHERE event_id < ?`)
+      .run(minCursor).changes as number;
+    const deletedEvents = db
+      .prepare(`DELETE FROM events WHERE id < ?`)
+      .run(minCursor).changes as number;
+
+    db.exec("COMMIT");
+    return {
+      deletedEvents,
+      deletedClaims,
+      minCursor,
+      latestId,
+      laggingAgents,
+    };
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
+};

--- a/src/event-queue.ts
+++ b/src/event-queue.ts
@@ -303,7 +303,7 @@ export const getAllCursors = (db: DatabaseSync): CursorRow[] => {
  * Push a sys.epoch event and advance every existing agent cursor to that
  * event's id. Atomic.
  */
-export const seekToTail = (
+export const setEpoch = (
   db: DatabaseSync,
 ): { event: Event; advancedAgentIds: string[] } => {
   db.exec("BEGIN");

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ import {
   getClaimant,
   getEventsSince,
   getOrOpenDb,
+  setEpoch,
   pushEvent,
-  seekToTail,
 } from "./event-queue.ts";
 import { cleanupGroupAsync } from "./lib/cleanup.ts";
 import { nextTick } from "./lib/promise.ts";
@@ -326,7 +326,7 @@ export default (pi: ExtensionAPI) => {
         "Push sys.epoch and advance all agent cursors to it (abandons backlog).",
       handler: async (_raw, ctx) => {
         await nextTick();
-        const { event, advancedAgentIds } = seekToTail(db);
+        const { event, advancedAgentIds } = setEpoch(db);
         ctx.ui.notify(
           `Pushed sys.epoch event #${event.id}; advanced ${advancedAgentIds.length} cursor(s)`,
           "info",

--- a/src/index.ts
+++ b/src/index.ts
@@ -334,8 +334,8 @@ export default (pi: ExtensionAPI) => {
       },
     });
 
-    // /busytown-compact-events — drop events already processed by all agents
-    pi.registerCommand("busytown-compact-events", {
+    // /busytown-compact-db — drop events already processed by all agents
+    pi.registerCommand("busytown-compact-db", {
       description:
         "Delete events already processed by all agents. Warns if any agent is >100 events behind.",
       handler: async (raw, ctx) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,12 @@ import path from "node:path";
 import { parseArgs } from "citty";
 import {
   claimEvent,
+  compactEvents,
   getClaimant,
   getEventsSince,
   getOrOpenDb,
   pushEvent,
+  seekToTail,
 } from "./event-queue.ts";
 import { cleanupGroupAsync } from "./lib/cleanup.ts";
 import { nextTick } from "./lib/promise.ts";
@@ -315,6 +317,49 @@ export default (pi: ExtensionAPI) => {
         await nextTick();
         const event = pushEvent(db, "pi", "sys.reload");
         ctx.ui.notify(`Pushed sys.reload event #${event.id}`, "info");
+      },
+    });
+
+    // /busytown-epoch — push sys.epoch and advance all agent cursors to tail
+    pi.registerCommand("busytown-epoch", {
+      description:
+        "Push sys.epoch and advance all agent cursors to it (abandons backlog).",
+      handler: async (_raw, ctx) => {
+        await nextTick();
+        const { event, advancedAgentIds } = seekToTail(db);
+        ctx.ui.notify(
+          `Pushed sys.epoch event #${event.id}; advanced ${advancedAgentIds.length} cursor(s)`,
+          "info",
+        );
+      },
+    });
+
+    // /busytown-compact-events — drop events already processed by all agents
+    pi.registerCommand("busytown-compact-events", {
+      description:
+        "Delete events already processed by all agents. Warns if any agent is >100 events behind.",
+      handler: async (raw, ctx) => {
+        await nextTick();
+        const args = parseArgs(shellSplit(raw ?? ""), {
+          "warn-threshold": {
+            type: "string" as const,
+            description: "Warn threshold (default: 100)",
+          },
+        });
+        const rawThreshold = args["warn-threshold"];
+        const parsed = rawThreshold ? parseInt(rawThreshold, 10) : 100;
+        const threshold = isNaN(parsed) ? 100 : parsed;
+        const result = compactEvents(db, threshold);
+        for (const { agent_id, behind } of result.laggingAgents) {
+          ctx.ui.notify(
+            `warning: agent "${agent_id}" is ${behind} events behind`,
+            "warning",
+          );
+        }
+        ctx.ui.notify(
+          `Compacted: deleted ${result.deletedEvents} event(s), ${result.deletedClaims} claim(s); cutoff=${result.minCursor}, tail=${result.latestId}`,
+          "info",
+        );
       },
     });
 


### PR DESCRIPTION
Adds two event-queue maintenance operations, each wired up as both a pi slash command and a `busytown` CLI subcommand:

- **`busytown epoch` / `/busytown-epoch`** — pushes a `sys.epoch` marker event and advances every existing agent cursor to its id. Use this to force all agents to abandon an unprocessed backlog and resume from "now".
- **`busytown compact-db` / `/busytown-compact-db`** — deletes events with `id < min(agent cursor)` (and their orphan claims). Warns per-agent, with the agent id, when any cursor is more than 100 events behind the tail — that agent is the one blocking further compaction.

## Notes

- **"Before the cursor" is strict (`<`, not `<=`).** Cursors point to the last processed event; keeping the cursor's anchor row makes debugging easier.
- **Atomic.** Both operations wrap their reads + writes in a single `BEGIN ... COMMIT`.
- **No-op on empty cursor set.** `compact-db` refuses to delete anything when no agents have registered — dropping the whole queue would be surprising.
- **Claims cleanup is manual.** The `claims` table has no FK cascade, so the compaction also runs `DELETE FROM claims WHERE event_id < minCursor`.
- **Threshold is configurable** via `--warn-threshold N` on both surfaces (default 100). CLI warnings go to stderr so they don't corrupt the JSON on stdout.

## Test plan

- [x] `npm test` — 283/283 pass (13 new).
- [x] `npm run check` — clean.
- [x] CLI smoke test against a temp db:
  - `busytown epoch` with no cursors pushes the event, leaves `advancedAgentIds: []`.
  - `busytown epoch` with cursors bumps them all to the new event's id.
  - `busytown compact-db` drops events strictly before the min cursor; leaves cursor-anchor events in place.
  - `busytown compact-db --warn-threshold 1` emits the expected `warning: agent "worker-slow" is 3 events behind` line on stderr.
- [ ] Interactive: exercise `/busytown-epoch` and `/busytown-compact-events` inside a running pi session to confirm the UI notifications look right.