### PR TITLE
fix!: Publish stderr as events

### DIFF
--- a/src/agents/shell-agent.test.ts
+++ b/src/agents/shell-agent.test.ts
@@ -78,55 +78,51 @@ describe("shellAgentHandler", () => {
     });
   });
 
-  it(
-    "sends stderr lines as stderr events",
-    { timeout: 5000 },
-    async () => {
-      const dbPath = createTempDbPath();
-      const ac = new AbortController();
-      const trigger = clientOf({ id: "trigger", dbPath });
-      const agentClient = clientOf({ id: "test-shell", dbPath });
-      const watcher = clientOf({ id: "watcher", dbPath });
+  it("sends stderr lines as stderr events", { timeout: 5000 }, async () => {
+    const dbPath = createTempDbPath();
+    const ac = new AbortController();
+    const trigger = clientOf({ id: "trigger", dbPath });
+    const agentClient = clientOf({ id: "test-shell", dbPath });
+    const watcher = clientOf({ id: "watcher", dbPath });
 
-      const triggerId = trigger.publish("test.run", {}).id;
+    const triggerId = trigger.publish("test.run", {}).id;
 
-      shellAgentHandler(
-        agentClient,
-        handlerConfig("echo out && echo err 1>&2", { signal: ac.signal }),
-      );
+    shellAgentHandler(
+      agentClient,
+      handlerConfig("echo out && echo err 1>&2", { signal: ac.signal }),
+    );
 
-      const collected: { type: string; payload: unknown }[] = [];
-      for await (const event of watcher.subscribe({
-        listen: ["agent.test-shell.*"],
-        pollInterval: 10,
-        signal: ac.signal,
-      })) {
-        collected.push({ type: event.type, payload: event.payload });
-        if (event.type === "agent.test-shell.end") break;
-      }
+    const collected: { type: string; payload: unknown }[] = [];
+    for await (const event of watcher.subscribe({
+      listen: ["agent.test-shell.*"],
+      pollInterval: 10,
+      signal: ac.signal,
+    })) {
+      collected.push({ type: event.type, payload: event.payload });
+      if (event.type === "agent.test-shell.end") break;
+    }
 
-      ac.abort();
+    ac.abort();
 
-      const stdoutEvents = collected.filter(
-        (e) => e.type === "agent.test-shell.stdout",
-      );
-      const stderrEvents = collected.filter(
-        (e) => e.type === "agent.test-shell.stderr",
-      );
+    const stdoutEvents = collected.filter(
+      (e) => e.type === "agent.test-shell.stdout",
+    );
+    const stderrEvents = collected.filter(
+      (e) => e.type === "agent.test-shell.stderr",
+    );
 
-      assert.equal(stdoutEvents.length, 1);
-      assert.deepEqual(stdoutEvents[0].payload, {
-        correlation_id: triggerId,
-        line: "out",
-      });
+    assert.equal(stdoutEvents.length, 1);
+    assert.deepEqual(stdoutEvents[0].payload, {
+      correlation_id: triggerId,
+      line: "out",
+    });
 
-      assert.equal(stderrEvents.length, 1);
-      assert.deepEqual(stderrEvents[0].payload, {
-        correlation_id: triggerId,
-        line: "err",
-      });
-    },
-  );
+    assert.equal(stderrEvents.length, 1);
+    assert.deepEqual(stderrEvents[0].payload, {
+      correlation_id: triggerId,
+      line: "err",
+    });
+  });
 
   it(
     "templates event fields into the shell script",

--- a/src/agents/shell-agent.test.ts
+++ b/src/agents/shell-agent.test.ts
@@ -32,14 +32,14 @@ const handlerConfig = (
 });
 
 describe("shellAgentHandler", () => {
-  it("sends stdout lines as output events", { timeout: 5000 }, async () => {
+  it("sends stdout lines as stdout events", { timeout: 5000 }, async () => {
     const dbPath = createTempDbPath();
     const ac = new AbortController();
     const trigger = clientOf({ id: "trigger", dbPath });
     const agentClient = clientOf({ id: "test-shell", dbPath });
     const watcher = clientOf({ id: "watcher", dbPath });
 
-    trigger.publish("test.run", {});
+    const triggerId = trigger.publish("test.run", {}).id;
 
     shellAgentHandler(
       agentClient,
@@ -65,12 +65,68 @@ describe("shellAgentHandler", () => {
     assert.ok(types.includes("agent.test-shell.end"));
 
     const outputs = collected.filter(
-      (e) => e.type === "agent.test-shell.output",
+      (e) => e.type === "agent.test-shell.stdout",
     );
     assert.equal(outputs.length, 2);
-    assert.deepEqual(outputs[0].payload, { line: "line one" });
-    assert.deepEqual(outputs[1].payload, { line: "line two" });
+    assert.deepEqual(outputs[0].payload, {
+      correlation_id: triggerId,
+      line: "line one",
+    });
+    assert.deepEqual(outputs[1].payload, {
+      correlation_id: triggerId,
+      line: "line two",
+    });
   });
+
+  it(
+    "sends stderr lines as stderr events",
+    { timeout: 5000 },
+    async () => {
+      const dbPath = createTempDbPath();
+      const ac = new AbortController();
+      const trigger = clientOf({ id: "trigger", dbPath });
+      const agentClient = clientOf({ id: "test-shell", dbPath });
+      const watcher = clientOf({ id: "watcher", dbPath });
+
+      const triggerId = trigger.publish("test.run", {}).id;
+
+      shellAgentHandler(
+        agentClient,
+        handlerConfig("echo out && echo err 1>&2", { signal: ac.signal }),
+      );
+
+      const collected: { type: string; payload: unknown }[] = [];
+      for await (const event of watcher.subscribe({
+        listen: ["agent.test-shell.*"],
+        pollInterval: 10,
+        signal: ac.signal,
+      })) {
+        collected.push({ type: event.type, payload: event.payload });
+        if (event.type === "agent.test-shell.end") break;
+      }
+
+      ac.abort();
+
+      const stdoutEvents = collected.filter(
+        (e) => e.type === "agent.test-shell.stdout",
+      );
+      const stderrEvents = collected.filter(
+        (e) => e.type === "agent.test-shell.stderr",
+      );
+
+      assert.equal(stdoutEvents.length, 1);
+      assert.deepEqual(stdoutEvents[0].payload, {
+        correlation_id: triggerId,
+        line: "out",
+      });
+
+      assert.equal(stderrEvents.length, 1);
+      assert.deepEqual(stderrEvents[0].payload, {
+        correlation_id: triggerId,
+        line: "err",
+      });
+    },
+  );
 
   it(
     "templates event fields into the shell script",
@@ -90,11 +146,14 @@ describe("shellAgentHandler", () => {
       );
 
       for await (const event of watcher.subscribe({
-        listen: ["agent.test-shell.output"],
+        listen: ["agent.test-shell.stdout"],
         pollInterval: 10,
         signal: ac.signal,
       })) {
-        assert.deepEqual(event.payload, { line: "test.hello" });
+        assert.deepEqual(
+          (event.payload as { line: string }).line,
+          "test.hello",
+        );
         break;
       }
 

--- a/src/agents/shell-agent.ts
+++ b/src/agents/shell-agent.ts
@@ -1,11 +1,8 @@
 import { spawn } from "node:child_process";
-import { loggerOf } from "../lib/json-logger.ts";
 import { renderTemplate } from "../lib/template.ts";
 import { stderr, stdout, lineStream } from "../lib/web-stream.ts";
 import type { EventClient } from "../sdk.ts";
 import type { ShellAgentDef } from "./file-agent-loader.ts";
-
-const logger = loggerOf({ source: "shell-agent.ts" });
 
 export type ShellAgentHandlerConfig = ShellAgentDef & {
   env?: Record<string, string | undefined>;
@@ -42,21 +39,6 @@ export const shellAgentHandler = async (
       env: { ...process.env, ...env },
     });
 
-    // Pipe stderr to logger (fire-and-forget)
-    stderr(proc)
-      .pipeThrough(lineStream())
-      .pipeTo(
-        new WritableStream({
-          write(line) {
-            logger.warn("stderr", { agent: id, line });
-          },
-        }),
-      )
-      .catch(() => {});
-
-    const lines = stdout(proc).pipeThrough(lineStream());
-    const reader = lines.getReader();
-
     const exitPromise = new Promise<{
       code: number | null;
       signal: string | null;
@@ -68,6 +50,24 @@ export const shellAgentHandler = async (
       correlation_id: correlationId,
       event_type: event.type,
     });
+
+    // Pipe stderr to events (fire-and-forget)
+    stderr(proc)
+      .pipeThrough(lineStream())
+      .pipeTo(
+        new WritableStream({
+          write(line) {
+            client.publish(`agent.${id}.stderr`, {
+              correlation_id: correlationId,
+              line,
+            });
+          },
+        }),
+      )
+      .catch(() => {});
+
+    const lines = stdout(proc).pipeThrough(lineStream());
+    const reader = lines.getReader();
 
     try {
       while (true) {
@@ -88,7 +88,10 @@ export const shellAgentHandler = async (
           }
           break;
         }
-        client.publish(`agent.${id}.output`, { line: value });
+        client.publish(`agent.${id}.stdout`, {
+          correlation_id: correlationId,
+          line: value,
+        });
       }
     } catch (e) {
       client.publish(`agent.${id}.error`, {


### PR DESCRIPTION
This will help us troubleshoot issues we've been having with shell agents.

Also changes `agent.<id>.output` to `agent.<id>.stdout` to match.