### PR TITLE
Add correlation_id, causation_id, depth

### DIFF
--- a/src/agents/pi-agent.ts
+++ b/src/agents/pi-agent.ts
@@ -76,8 +76,6 @@ export const piAgentHandler = async (
     pollInterval,
     signal,
   })) {
-    const correlationId = event.id;
-
     const proc = spawn("pi", cliArgs, {
       stdio: ["pipe", "pipe", "pipe"],
       cwd,
@@ -126,10 +124,7 @@ export const piAgentHandler = async (
       proc.once("exit", (code, signal) => resolve({ code, signal }));
     });
 
-    client.publish(`agent.${id}.start`, {
-      correlation_id: correlationId,
-      event_type: event.type,
-    });
+    client.publish(`agent.${id}.start`, { event_type: event.type }, event);
 
     try {
       while (true) {
@@ -137,33 +132,31 @@ export const piAgentHandler = async (
         if (done) {
           const { code, signal } = await exitPromise;
           if (code !== 0 && code !== null) {
-            client.publish(`agent.${id}.error`, {
-              error: `Process exited unexpectedly (code ${code})`,
-              correlation_id: correlationId,
-              code,
-              signal,
-            });
+            client.publish(
+              `agent.${id}.error`,
+              {
+                error: `Process exited unexpectedly (code ${code})`,
+                code,
+                signal,
+              },
+              event,
+            );
           }
           break;
         }
 
-        const sessionEvent = fromPiAgentSessionEvent(value, correlationId);
+        const sessionEvent = fromPiAgentSessionEvent(value);
         if (sessionEvent) {
-          client.publish(`agent.${id}.message`, sessionEvent);
+          client.publish(`agent.${id}.message`, sessionEvent, event);
         }
 
         if (value.type === "agent_end") {
-          client.publish(`agent.${id}.end`, {
-            correlation_id: correlationId,
-          });
+          client.publish(`agent.${id}.end`, {}, event);
           break;
         }
       }
     } catch (e) {
-      client.publish(`agent.${id}.error`, {
-        error: `${e}`,
-        correlation_id: correlationId,
-      });
+      client.publish(`agent.${id}.error`, { error: `${e}` }, event);
     } finally {
       signal.removeEventListener("abort", onAbort);
       reader.releaseLock();

--- a/src/agents/pi-agent.ts
+++ b/src/agents/pi-agent.ts
@@ -124,7 +124,7 @@ export const piAgentHandler = async (
       proc.once("exit", (code, signal) => resolve({ code, signal }));
     });
 
-    client.publish(`agent.${id}.start`, { event_type: event.type }, event);
+    client.publish(`agent.${id}.start`, {}, event);
 
     try {
       while (true) {

--- a/src/agents/pi-rpc-agent.ts
+++ b/src/agents/pi-rpc-agent.ts
@@ -134,7 +134,7 @@ export const piRpcAgentHandler = async (
     pollInterval,
     signal: loopAbortSignal,
   })) {
-    client.publish(`agent.${id}.start`, { event_type: event.type }, event);
+    client.publish(`agent.${id}.start`, {}, event);
 
     const isCompact = event.type === `agent.${id}.compact`;
     const isNewSession = event.type === `agent.${id}.new_session`;

--- a/src/agents/pi-rpc-agent.ts
+++ b/src/agents/pi-rpc-agent.ts
@@ -134,12 +134,7 @@ export const piRpcAgentHandler = async (
     pollInterval,
     signal: loopAbortSignal,
   })) {
-    const correlationId = event.id;
-
-    client.publish(`agent.${id}.start`, {
-      correlation_id: correlationId,
-      event_type: event.type,
-    });
+    client.publish(`agent.${id}.start`, { event_type: event.type }, event);
 
     const isCompact = event.type === `agent.${id}.compact`;
     const isNewSession = event.type === `agent.${id}.new_session`;
@@ -163,9 +158,9 @@ export const piRpcAgentHandler = async (
         }
 
         if (!isPiRpcResponse(value)) {
-          const sessionEvent = fromPiAgentSessionEvent(value, correlationId);
+          const sessionEvent = fromPiAgentSessionEvent(value);
           if (sessionEvent) {
-            client.publish(`agent.${id}.message`, sessionEvent);
+            client.publish(`agent.${id}.message`, sessionEvent, event);
           }
         }
 
@@ -189,17 +184,12 @@ export const piRpcAgentHandler = async (
             : value.type === "agent_end";
 
         if (isDone) {
-          client.publish(`agent.${id}.end`, {
-            correlation_id: correlationId,
-          });
+          client.publish(`agent.${id}.end`, {}, event);
           break;
         }
       }
     } catch (e) {
-      client.publish(`agent.${id}.error`, {
-        error: String(e),
-        correlation_id: correlationId,
-      });
+      client.publish(`agent.${id}.error`, { error: String(e) }, event);
     }
   }
 

--- a/src/agents/shell-agent.test.ts
+++ b/src/agents/shell-agent.test.ts
@@ -48,13 +48,25 @@ describe("shellAgentHandler", () => {
       }),
     );
 
-    const collected: { type: string; payload: unknown }[] = [];
+    const collected: {
+      type: string;
+      payload: unknown;
+      correlation_id?: number;
+      causation_id?: number;
+      depth: number;
+    }[] = [];
     for await (const event of watcher.subscribe({
       listen: ["agent.test-shell.*"],
       pollInterval: 10,
       signal: ac.signal,
     })) {
-      collected.push({ type: event.type, payload: event.payload });
+      collected.push({
+        type: event.type,
+        payload: event.payload,
+        correlation_id: event.correlation_id,
+        causation_id: event.causation_id,
+        depth: event.depth,
+      });
       if (event.type === "agent.test-shell.end") break;
     }
 
@@ -68,14 +80,16 @@ describe("shellAgentHandler", () => {
       (e) => e.type === "agent.test-shell.stdout",
     );
     assert.equal(outputs.length, 2);
-    assert.deepEqual(outputs[0].payload, {
-      correlation_id: triggerId,
-      line: "line one",
-    });
-    assert.deepEqual(outputs[1].payload, {
-      correlation_id: triggerId,
-      line: "line two",
-    });
+    assert.deepEqual(outputs[0].payload, { line: "line one" });
+    assert.deepEqual(outputs[1].payload, { line: "line two" });
+
+    // Causality is now on the event row, not the payload. Trigger is the
+    // root, so caused events get correlation_id = causation_id = trigger.id.
+    for (const e of collected) {
+      assert.equal(e.causation_id, triggerId);
+      assert.equal(e.correlation_id, triggerId);
+      assert.equal(e.depth, 1);
+    }
   });
 
   it("sends stderr lines as stderr events", { timeout: 5000 }, async () => {
@@ -92,13 +106,23 @@ describe("shellAgentHandler", () => {
       handlerConfig("echo out && echo err 1>&2", { signal: ac.signal }),
     );
 
-    const collected: { type: string; payload: unknown }[] = [];
+    const collected: {
+      type: string;
+      payload: unknown;
+      correlation_id?: number;
+      causation_id?: number;
+    }[] = [];
     for await (const event of watcher.subscribe({
       listen: ["agent.test-shell.*"],
       pollInterval: 10,
       signal: ac.signal,
     })) {
-      collected.push({ type: event.type, payload: event.payload });
+      collected.push({
+        type: event.type,
+        payload: event.payload,
+        correlation_id: event.correlation_id,
+        causation_id: event.causation_id,
+      });
       if (event.type === "agent.test-shell.end") break;
     }
 
@@ -112,16 +136,14 @@ describe("shellAgentHandler", () => {
     );
 
     assert.equal(stdoutEvents.length, 1);
-    assert.deepEqual(stdoutEvents[0].payload, {
-      correlation_id: triggerId,
-      line: "out",
-    });
+    assert.deepEqual(stdoutEvents[0].payload, { line: "out" });
+    assert.equal(stdoutEvents[0].causation_id, triggerId);
+    assert.equal(stdoutEvents[0].correlation_id, triggerId);
 
     assert.equal(stderrEvents.length, 1);
-    assert.deepEqual(stderrEvents[0].payload, {
-      correlation_id: triggerId,
-      line: "err",
-    });
+    assert.deepEqual(stderrEvents[0].payload, { line: "err" });
+    assert.equal(stderrEvents[0].causation_id, triggerId);
+    assert.equal(stderrEvents[0].correlation_id, triggerId);
   });
 
   it(

--- a/src/agents/shell-agent.ts
+++ b/src/agents/shell-agent.ts
@@ -44,7 +44,7 @@ export const shellAgentHandler = async (
       proc.once("exit", (code, signal) => resolve({ code, signal }));
     });
 
-    client.publish(`agent.${id}.start`, { event_type: event.type }, event);
+    client.publish(`agent.${id}.start`, {}, event);
 
     // Pipe stderr to events (fire-and-forget)
     stderr(proc)

--- a/src/agents/shell-agent.ts
+++ b/src/agents/shell-agent.ts
@@ -30,8 +30,6 @@ export const shellAgentHandler = async (
     pollInterval,
     signal,
   })) {
-    const correlationId = event.id;
-
     const rendered = renderTemplate(body, { event });
 
     const proc = spawn("/bin/sh", ["-c", rendered], {
@@ -46,10 +44,7 @@ export const shellAgentHandler = async (
       proc.once("exit", (code, signal) => resolve({ code, signal }));
     });
 
-    client.publish(`agent.${id}.start`, {
-      correlation_id: correlationId,
-      event_type: event.type,
-    });
+    client.publish(`agent.${id}.start`, { event_type: event.type }, event);
 
     // Pipe stderr to events (fire-and-forget)
     stderr(proc)
@@ -57,10 +52,7 @@ export const shellAgentHandler = async (
       .pipeTo(
         new WritableStream({
           write(line) {
-            client.publish(`agent.${id}.stderr`, {
-              correlation_id: correlationId,
-              line,
-            });
+            client.publish(`agent.${id}.stderr`, { line }, event);
           },
         }),
       )
@@ -75,29 +67,24 @@ export const shellAgentHandler = async (
         if (done) {
           const { code, signal } = await exitPromise;
           if (code !== 0 && code !== null) {
-            client.publish(`agent.${id}.error`, {
-              error: `Process exited unexpectedly (code ${code})`,
-              correlation_id: correlationId,
-              code,
-              signal,
-            });
+            client.publish(
+              `agent.${id}.error`,
+              {
+                error: `Process exited unexpectedly (code ${code})`,
+                code,
+                signal,
+              },
+              event,
+            );
           } else {
-            client.publish(`agent.${id}.end`, {
-              correlation_id: correlationId,
-            });
+            client.publish(`agent.${id}.end`, {}, event);
           }
           break;
         }
-        client.publish(`agent.${id}.stdout`, {
-          correlation_id: correlationId,
-          line: value,
-        });
+        client.publish(`agent.${id}.stdout`, { line: value }, event);
       }
     } catch (e) {
-      client.publish(`agent.${id}.error`, {
-        error: `${e}`,
-        correlation_id: correlationId,
-      });
+      client.publish(`agent.${id}.error`, { error: `${e}` }, event);
     } finally {
       reader.releaseLock();
     }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -7,7 +7,7 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import type { AgentDef } from "./agents/file-agent-loader.ts";
 import type { Event } from "./lib/event.ts";
-import { getEventsSince } from "./event-queue.ts";
+import { getEventById, getEventsSince } from "./event-queue.ts";
 import { getDaemonStatus } from "./daemon-state.ts";
 import { pushBuffer } from "./lib/buffer.ts";
 import { storeOf } from "./lib/store.ts";
@@ -59,15 +59,13 @@ const AGENT_EVENT_RE = /^agent\.(.+)\.(start|end|error)$/;
 const applyAgentEvent = (
   agent: AgentState,
   action: string,
-  payload: unknown,
+  triggerType: string | undefined,
 ): AgentState => {
   if (action === "start") {
     return {
       ...agent,
       status: "running",
-      eventType: (payload as Record<string, unknown>)?.event_type as
-        | string
-        | undefined,
+      eventType: triggerType,
       progressChars: undefined,
     };
   }
@@ -85,44 +83,47 @@ const applyAgentEvent = (
   return agent;
 };
 
-const dashboardReducer = (
-  state: DashboardState,
-  action: DashboardAction,
-): DashboardState => {
-  if (action.type === "daemon_status") {
-    return action.running === state.daemonRunning
-      ? state
-      : { ...state, daemonRunning: action.running };
-  }
+const dashboardReducerOf =
+  (db: DatabaseSync) =>
+  (state: DashboardState, action: DashboardAction): DashboardState => {
+    if (action.type === "daemon_status") {
+      return action.running === state.daemonRunning
+        ? state
+        : { ...state, daemonRunning: action.running };
+    }
 
-  if (action.type === "agents_reloaded") {
-    return { ...state, agents: buildInitialAgents(action.agents) };
-  }
+    if (action.type === "agents_reloaded") {
+      return { ...state, agents: buildInitialAgents(action.agents) };
+    }
 
-  let agents = state.agents;
+    let agents = state.agents;
 
-  for (const event of action.events) {
-    const match = event.type.match(AGENT_EVENT_RE);
-    if (match) {
-      const [, agentId, agentAction] = match;
-      const existing = agents.get(agentId!);
-      if (existing) {
-        const updated = applyAgentEvent(existing, agentAction!, event.payload);
-        if (updated !== existing) {
-          // Copy-on-first-write
-          if (agents === state.agents) agents = new Map(state.agents);
-          agents.set(agentId!, updated);
+    for (const event of action.events) {
+      const match = event.type.match(AGENT_EVENT_RE);
+      if (match) {
+        const [, agentId, agentAction] = match;
+        const existing = agents.get(agentId!);
+        if (existing) {
+          const triggerType =
+            agentAction === "start" && event.causation_id != null
+              ? getEventById(db, event.causation_id)?.type
+              : undefined;
+          const updated = applyAgentEvent(existing, agentAction!, triggerType);
+          if (updated !== existing) {
+            // Copy-on-first-write
+            if (agents === state.agents) agents = new Map(state.agents);
+            agents.set(agentId!, updated);
+          }
         }
       }
     }
-  }
 
-  const lastSeenId = action.events[action.events.length - 1]!.id;
+    const lastSeenId = action.events[action.events.length - 1]!.id;
 
-  return agents === state.agents && lastSeenId === state.lastSeenId
-    ? state
-    : { ...state, agents, lastSeenId };
-};
+    return agents === state.agents && lastSeenId === state.lastSeenId
+      ? state
+      : { ...state, agents, lastSeenId };
+  };
 
 // ---------------------------------------------------------------------------
 // Widget (below editor)
@@ -186,7 +187,7 @@ export const startWidget = (
   const tip = getEventsSince(db, { tail: 1 });
   const initialLastSeenId = tip.length > 0 ? tip[0]!.id : 0;
 
-  const store = storeOf(dashboardReducer, {
+  const store = storeOf(dashboardReducerOf(db), {
     agents: buildInitialAgents(agents),
     daemonRunning: getDaemonStatus(projectRoot).running,
     lastSeenId: initialLastSeenId,

--- a/src/event-queue.test.ts
+++ b/src/event-queue.test.ts
@@ -47,6 +47,56 @@ describe("pushEvent", () => {
     assert.deepEqual(event.payload, {});
     db.close();
   });
+
+  it("root event (no cause) has depth=0 and undefined correlation/causation", () => {
+    const db = createTestDb();
+    const root = pushEvent(db, "w", "root");
+    assert.equal(root.depth, 0);
+    assert.equal(root.correlation_id, undefined);
+    assert.equal(root.causation_id, undefined);
+    db.close();
+  });
+
+  it("event caused by a root carries correlation_id=root.id and causation_id=root.id", () => {
+    const db = createTestDb();
+    const root = pushEvent(db, "w", "root");
+    const child = pushEvent(db, "w", "child", {}, root);
+    assert.equal(child.causation_id, root.id);
+    assert.equal(child.correlation_id, root.id);
+    assert.equal(child.depth, 1);
+    db.close();
+  });
+
+  it("correlation_id carries forward, causation_id and depth track the immediate parent", () => {
+    const db = createTestDb();
+    const root = pushEvent(db, "w", "root");
+    const child = pushEvent(db, "w", "child", {}, root);
+    const grandchild = pushEvent(db, "w", "grandchild", {}, child);
+
+    assert.equal(grandchild.correlation_id, root.id);
+    assert.equal(grandchild.causation_id, child.id);
+    assert.equal(grandchild.depth, 2);
+    db.close();
+  });
+
+  it("persists correlation_id, causation_id, depth across read/write", () => {
+    const db = createTestDb();
+    const root = pushEvent(db, "w", "root");
+    const child = pushEvent(db, "w", "child", {}, root);
+
+    // Read back via getEventsSince to exercise parseEvent
+    const events = getEventsSince(db, { sinceId: 0, limit: 100 });
+    const reread = events.find((e) => e.id === child.id)!;
+    assert.equal(reread.correlation_id, root.id);
+    assert.equal(reread.causation_id, root.id);
+    assert.equal(reread.depth, 1);
+
+    const rereadRoot = events.find((e) => e.id === root.id)!;
+    assert.equal(rereadRoot.correlation_id, undefined);
+    assert.equal(rereadRoot.causation_id, undefined);
+    assert.equal(rereadRoot.depth, 0);
+    db.close();
+  });
 });
 
 describe("getCursor / updateCursor", () => {

--- a/src/event-queue.ts
+++ b/src/event-queue.ts
@@ -8,13 +8,17 @@ const SCHEMA = `
   PRAGMA journal_mode = WAL;
   PRAGMA busy_timeout = 5000;
   PRAGMA foreign_keys = ON;
+  PRAGMA user_version = 1;
 
   CREATE TABLE IF NOT EXISTS events (
-    id        INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp INTEGER NOT NULL DEFAULT (unixepoch()),
-    type      TEXT    NOT NULL,
-    agent_id  TEXT    NOT NULL,
-    payload   TEXT    NOT NULL DEFAULT '{}'
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp       INTEGER NOT NULL DEFAULT (unixepoch()),
+    type            TEXT    NOT NULL,
+    agent_id        TEXT    NOT NULL,
+    correlation_id  INTEGER,
+    causation_id    INTEGER,
+    depth           INTEGER NOT NULL DEFAULT 0,
+    payload         TEXT    NOT NULL DEFAULT '{}'
   );
 
   CREATE TABLE IF NOT EXISTS agent_cursors (
@@ -45,7 +49,13 @@ export const openDb = (dbPath: string): DatabaseSync => {
 export const getOrOpenDb = memoize(openDb, (dbPath) => dbPath);
 
 const parseEvent = (row: RawEventRow): Event => ({
-  ...row,
+  id: row.id,
+  timestamp: row.timestamp,
+  type: row.type,
+  agent_id: row.agent_id,
+  correlation_id: row.correlation_id ?? undefined,
+  causation_id: row.causation_id ?? undefined,
+  depth: row.depth,
   payload: JSON.parse(row.payload),
 });
 
@@ -54,14 +64,26 @@ export const pushEvent = (
   agentId: string,
   type: string,
   payload: unknown = {},
+  cause?: Event,
 ): Event => {
+  const correlationId = cause ? (cause.correlation_id ?? cause.id) : undefined;
+  const causationId = cause?.id;
+  const depth = cause ? cause.depth + 1 : 0;
+
   const row = db
     .prepare(
-      `INSERT INTO events (type, agent_id, payload)
-       VALUES (?, ?, ?)
+      `INSERT INTO events (type, agent_id, correlation_id, causation_id, depth, payload)
+       VALUES (?, ?, ?, ?, ?, ?)
        RETURNING id, timestamp`,
     )
-    .get(type, agentId, JSON.stringify(payload)) as {
+    .get(
+      type,
+      agentId,
+      correlationId ?? null,
+      causationId ?? null,
+      depth,
+      JSON.stringify(payload),
+    ) as {
     id: number;
     timestamp: number;
   };
@@ -71,6 +93,9 @@ export const pushEvent = (
     timestamp: row.timestamp,
     type,
     agent_id: agentId,
+    correlation_id: correlationId,
+    causation_id: causationId,
+    depth,
     payload,
   };
 };

--- a/src/event-queue.ts
+++ b/src/event-queue.ts
@@ -218,6 +218,16 @@ export const getNextEvent = (
   sinceId: number,
 ): Event | undefined => getNextEvents(db, sinceId, 1).at(0);
 
+export const getEventById = (
+  db: DatabaseSync,
+  id: number,
+): Event | undefined => {
+  const row = db.prepare(`SELECT * FROM events WHERE id = ?`).get(id) as
+    | RawEventRow
+    | undefined;
+  return row ? parseEvent(row) : undefined;
+};
+
 export const pullNextMatchingEvent = (
   db: DatabaseSync,
   id: string,

--- a/src/lib/agent-session-event.test.ts
+++ b/src/lib/agent-session-event.test.ts
@@ -14,8 +14,6 @@ const PARTIAL = { role: "assistant", content: [] };
 /** Clone AGENT_MSG with overrides — used for message_end error tests. */
 const assistantMsg = (overrides: object) => ({ ...AGENT_MSG, ...overrides });
 
-const CID = 42;
-
 /** Wrap an assistantMessageEvent in a message_update Pi event. */
 const update = (assistantMessageEvent: object) =>
   pi({
@@ -26,33 +24,27 @@ const update = (assistantMessageEvent: object) =>
 
 describe("fromPiAgentSessionEvent", () => {
   describe("agent lifecycle", () => {
-    it("maps agent_start with correlation_id", () => {
-      assert.deepEqual(
-        fromPiAgentSessionEvent(pi({ type: "agent_start" }), CID),
-        {
-          type: "agent_start",
-          correlation_id: CID,
-        },
-      );
+    it("maps agent_start", () => {
+      assert.deepEqual(fromPiAgentSessionEvent(pi({ type: "agent_start" })), {
+        type: "agent_start",
+      });
     });
 
     it("maps agent_end, strips messages", () => {
       assert.deepEqual(
         fromPiAgentSessionEvent(
           pi({ type: "agent_end", messages: [AGENT_MSG] }),
-          CID,
         ),
-        { type: "agent_end", correlation_id: CID },
+        { type: "agent_end" },
       );
     });
   });
 
   describe("turn lifecycle", () => {
     it("maps turn_start", () => {
-      assert.deepEqual(
-        fromPiAgentSessionEvent(pi({ type: "turn_start" }), CID),
-        { type: "turn_start", correlation_id: CID },
-      );
+      assert.deepEqual(fromPiAgentSessionEvent(pi({ type: "turn_start" })), {
+        type: "turn_start",
+      });
     });
 
     it("maps turn_end, strips message and toolResults", () => {
@@ -63,9 +55,8 @@ describe("fromPiAgentSessionEvent", () => {
             message: AGENT_MSG,
             toolResults: TOOL_RESULTS,
           }),
-          CID,
         ),
-        { type: "turn_end", correlation_id: CID },
+        { type: "turn_end" },
       );
     });
   });
@@ -75,7 +66,6 @@ describe("fromPiAgentSessionEvent", () => {
       assert.equal(
         fromPiAgentSessionEvent(
           pi({ type: "message_start", message: AGENT_MSG }),
-          CID,
         ),
         undefined,
       );
@@ -85,7 +75,6 @@ describe("fromPiAgentSessionEvent", () => {
       assert.equal(
         fromPiAgentSessionEvent(
           pi({ type: "message_end", message: AGENT_MSG }),
-          CID,
         ),
         undefined,
       );
@@ -103,11 +92,9 @@ describe("fromPiAgentSessionEvent", () => {
               errorMessage: '400 {"type":"error", … plan limits …}',
             }),
           }),
-          CID,
         ),
         {
           type: "error",
-          correlation_id: CID,
           message: '400 {"type":"error", … plan limits …}',
           code: "error",
         },
@@ -121,11 +108,9 @@ describe("fromPiAgentSessionEvent", () => {
             type: "message_end",
             message: assistantMsg({ stopReason: "aborted" }),
           }),
-          CID,
         ),
         {
           type: "error",
-          correlation_id: CID,
           message: "aborted",
           code: "aborted",
         },
@@ -139,7 +124,6 @@ describe("fromPiAgentSessionEvent", () => {
             type: "message_end",
             message: assistantMsg({ stopReason: "stop" }),
           }),
-          CID,
         ),
         undefined,
       );
@@ -152,7 +136,6 @@ describe("fromPiAgentSessionEvent", () => {
             type: "message_end",
             message: { role: "user", content: "hello" },
           }),
-          CID,
         ),
         undefined,
       );
@@ -170,7 +153,6 @@ describe("fromPiAgentSessionEvent", () => {
               isError: false,
             },
           }),
-          CID,
         ),
         undefined,
       );
@@ -182,9 +164,8 @@ describe("fromPiAgentSessionEvent", () => {
       assert.deepEqual(
         fromPiAgentSessionEvent(
           update({ type: "thinking_start", contentIndex: 0, partial: PARTIAL }),
-          CID,
         ),
-        { type: "thinking_start", correlation_id: CID, contentIndex: 0 },
+        { type: "thinking_start", contentIndex: 0 },
       );
     });
 
@@ -197,11 +178,9 @@ describe("fromPiAgentSessionEvent", () => {
             content: "I should search first",
             partial: PARTIAL,
           }),
-          CID,
         ),
         {
           type: "thinking_end",
-          correlation_id: CID,
           contentIndex: 0,
           content: "I should search first",
         },
@@ -214,9 +193,8 @@ describe("fromPiAgentSessionEvent", () => {
       assert.deepEqual(
         fromPiAgentSessionEvent(
           update({ type: "text_start", contentIndex: 1, partial: PARTIAL }),
-          CID,
         ),
-        { type: "text_start", correlation_id: CID, contentIndex: 1 },
+        { type: "text_start", contentIndex: 1 },
       );
     });
 
@@ -229,11 +207,9 @@ describe("fromPiAgentSessionEvent", () => {
             content: "Hello world",
             partial: PARTIAL,
           }),
-          CID,
         ),
         {
           type: "text_end",
-          correlation_id: CID,
           contentIndex: 1,
           content: "Hello world",
         },
@@ -246,9 +222,8 @@ describe("fromPiAgentSessionEvent", () => {
       assert.deepEqual(
         fromPiAgentSessionEvent(
           update({ type: "toolcall_start", contentIndex: 2, partial: PARTIAL }),
-          CID,
         ),
-        { type: "toolcall_start", correlation_id: CID, contentIndex: 2 },
+        { type: "toolcall_start", contentIndex: 2 },
       );
     });
 
@@ -267,11 +242,9 @@ describe("fromPiAgentSessionEvent", () => {
               thoughtSignature: "sig_abc",
             },
           }),
-          CID,
         ),
         {
           type: "toolcall_end",
-          correlation_id: CID,
           contentIndex: 2,
           tool_call_id: "call_1",
           name: "bash",
@@ -291,7 +264,6 @@ describe("fromPiAgentSessionEvent", () => {
             delta: "hel",
             partial: PARTIAL,
           }),
-          CID,
         ),
         undefined,
       );
@@ -306,7 +278,6 @@ describe("fromPiAgentSessionEvent", () => {
             delta: "hmm",
             partial: PARTIAL,
           }),
-          CID,
         ),
         undefined,
       );
@@ -321,7 +292,6 @@ describe("fromPiAgentSessionEvent", () => {
             delta: '{"cmd"',
             partial: PARTIAL,
           }),
-          CID,
         ),
         undefined,
       );
@@ -331,10 +301,7 @@ describe("fromPiAgentSessionEvent", () => {
   describe("message_update envelope sub-events are dropped", () => {
     it("returns undefined for start", () => {
       assert.equal(
-        fromPiAgentSessionEvent(
-          update({ type: "start", partial: PARTIAL }),
-          CID,
-        ),
+        fromPiAgentSessionEvent(update({ type: "start", partial: PARTIAL })),
         undefined,
       );
     });
@@ -343,7 +310,6 @@ describe("fromPiAgentSessionEvent", () => {
       assert.equal(
         fromPiAgentSessionEvent(
           update({ type: "done", reason: "stop", message: AGENT_MSG }),
-          CID,
         ),
         undefined,
       );
@@ -355,11 +321,9 @@ describe("fromPiAgentSessionEvent", () => {
       assert.deepEqual(
         fromPiAgentSessionEvent(
           update({ type: "error", reason: "aborted", error: AGENT_MSG }),
-          CID,
         ),
         {
           type: "error",
-          correlation_id: CID,
           message: "aborted",
           code: "aborted",
         },
@@ -377,7 +341,6 @@ describe("fromPiAgentSessionEvent", () => {
             toolName: "bash",
             args: { command: "ls" },
           }),
-          CID,
         ),
         undefined,
       );
@@ -393,7 +356,6 @@ describe("fromPiAgentSessionEvent", () => {
             args: { command: "ls" },
             partialResult: "partial...",
           }),
-          CID,
         ),
         undefined,
       );
@@ -409,11 +371,9 @@ describe("fromPiAgentSessionEvent", () => {
             result: "file1.ts\nfile2.ts",
             isError: false,
           }),
-          CID,
         ),
         {
           type: "tool_execution_end",
-          correlation_id: CID,
           tool_call_id: "call_1",
           output: "file1.ts\nfile2.ts",
           isError: false,
@@ -431,11 +391,9 @@ describe("fromPiAgentSessionEvent", () => {
             result: "command not found",
             isError: true,
           }),
-          CID,
         ),
         {
           type: "tool_execution_end",
-          correlation_id: CID,
           tool_call_id: "call_2",
           output: "command not found",
           isError: true,
@@ -449,9 +407,8 @@ describe("fromPiAgentSessionEvent", () => {
       assert.deepEqual(
         fromPiAgentSessionEvent(
           pi({ type: "compaction_start", reason: "threshold" }),
-          CID,
         ),
-        { type: "compaction_start", correlation_id: CID, reason: "threshold" },
+        { type: "compaction_start", reason: "threshold" },
       );
     });
 
@@ -470,11 +427,9 @@ describe("fromPiAgentSessionEvent", () => {
             aborted: false,
             willRetry: false,
           }),
-          CID,
         ),
         {
           type: "compaction_end",
-          correlation_id: CID,
           reason: "threshold",
           result: {
             summary: "Summarized",
@@ -497,11 +452,9 @@ describe("fromPiAgentSessionEvent", () => {
             aborted: true,
             willRetry: true,
           }),
-          CID,
         ),
         {
           type: "compaction_end",
-          correlation_id: CID,
           reason: "overflow",
           result: undefined,
           aborted: true,
@@ -522,11 +475,9 @@ describe("fromPiAgentSessionEvent", () => {
             delayMs: 2000,
             errorMessage: "529 overloaded",
           }),
-          CID,
         ),
         {
           type: "auto_retry_start",
-          correlation_id: CID,
           attempt: 1,
           maxAttempts: 3,
           delayMs: 2000,
@@ -539,11 +490,9 @@ describe("fromPiAgentSessionEvent", () => {
       assert.deepEqual(
         fromPiAgentSessionEvent(
           pi({ type: "auto_retry_end", success: true, attempt: 2 }),
-          CID,
         ),
         {
           type: "auto_retry_end",
-          correlation_id: CID,
           success: true,
           finalError: undefined,
         },
@@ -559,11 +508,9 @@ describe("fromPiAgentSessionEvent", () => {
             attempt: 3,
             finalError: "still overloaded",
           }),
-          CID,
         ),
         {
           type: "auto_retry_end",
-          correlation_id: CID,
           success: false,
           finalError: "still overloaded",
         },

--- a/src/lib/agent-session-event.ts
+++ b/src/lib/agent-session-event.ts
@@ -2,8 +2,8 @@
 // Simplified agent session events
 //
 // One event per logical stage — no streaming deltas, no message wrapper.
-// Every event within a run carries a `correlation_id` that matches the
-// originating `user_message` id.
+// Causality is tracked by the queue itself via correlation_id / causation_id
+// columns; publishers pass the originating event as `cause` to client.publish.
 //
 // See docs/simplified-llm-events.md for the full design.
 // ---------------------------------------------------------------------------
@@ -19,57 +19,48 @@ export type UserMessage = {
 
 export type AgentStart = {
   type: "agent_start";
-  correlation_id: number;
 };
 
 export type AgentEnd = {
   type: "agent_end";
-  correlation_id: number;
   total_input_tokens?: number;
   total_output_tokens?: number;
 };
 
 export type TurnStart = {
   type: "turn_start";
-  correlation_id: number;
 };
 
 export type TurnEnd = {
   type: "turn_end";
-  correlation_id: number;
   input_tokens?: number;
   output_tokens?: number;
 };
 
 export type ThinkingStart = {
   type: "thinking_start";
-  correlation_id: number;
   contentIndex: number;
 };
 
 export type ThinkingEnd = {
   type: "thinking_end";
-  correlation_id: number;
   contentIndex: number;
   content: string;
 };
 
 export type TextStart = {
   type: "text_start";
-  correlation_id: number;
   contentIndex: number;
 };
 
 export type TextEnd = {
   type: "text_end";
-  correlation_id: number;
   contentIndex: number;
   content: string;
 };
 
 export type ToolcallStart = {
   type: "toolcall_start";
-  correlation_id: number;
   contentIndex: number;
   tool_call_id?: string;
   name?: string;
@@ -77,7 +68,6 @@ export type ToolcallStart = {
 
 export type ToolcallEnd = {
   type: "toolcall_end";
-  correlation_id: number;
   contentIndex: number;
   tool_call_id: string;
   name: string;
@@ -86,7 +76,6 @@ export type ToolcallEnd = {
 
 export type ToolExecutionEnd = {
   type: "tool_execution_end";
-  correlation_id: number;
   tool_call_id: string;
   output: unknown;
   isError: boolean;
@@ -94,20 +83,17 @@ export type ToolExecutionEnd = {
 
 export type AgentError = {
   type: "error";
-  correlation_id: number;
   message: string;
   code?: "error" | "aborted";
 };
 
 export type CompactionStart = {
   type: "compaction_start";
-  correlation_id: number;
   reason: "manual" | "threshold" | "overflow";
 };
 
 export type CompactionEnd = {
   type: "compaction_end";
-  correlation_id: number;
   reason: "manual" | "threshold" | "overflow";
   result:
     | { summary: string; firstKeptEntryId: string; tokensBefore: number }
@@ -118,7 +104,6 @@ export type CompactionEnd = {
 
 export type AutoRetryStart = {
   type: "auto_retry_start";
-  correlation_id: number;
   attempt: number;
   maxAttempts: number;
   delayMs: number;
@@ -127,7 +112,6 @@ export type AutoRetryStart = {
 
 export type AutoRetryEnd = {
   type: "auto_retry_end";
-  correlation_id: number;
   success: boolean;
   finalError?: string;
 };
@@ -168,26 +152,22 @@ export type AgentSessionEvent =
  */
 export const fromPiAgentSessionEvent = (
   event: PiAgentSessionEvent,
-  correlationId: number,
 ): AgentSessionEvent | undefined => {
   switch (event.type) {
     case "agent_start":
-      return { type: "agent_start", correlation_id: correlationId };
+      return { type: "agent_start" };
 
     case "agent_end":
-      return { type: "agent_end", correlation_id: correlationId };
+      return { type: "agent_end" };
 
     case "turn_start":
-      return { type: "turn_start", correlation_id: correlationId };
+      return { type: "turn_start" };
 
     case "turn_end":
-      return { type: "turn_end", correlation_id: correlationId };
+      return { type: "turn_end" };
 
     case "message_update":
-      return fromAssistantMessageEvent(
-        event.assistantMessageEvent,
-        correlationId,
-      );
+      return fromAssistantMessageEvent(event.assistantMessageEvent);
 
     case "tool_execution_start":
       // Simplified model has no tool_execution_start — info is on toolcall_start/end
@@ -200,7 +180,6 @@ export const fromPiAgentSessionEvent = (
     case "tool_execution_end":
       return {
         type: "tool_execution_end",
-        correlation_id: correlationId,
         tool_call_id: event.toolCallId,
         output: event.result,
         isError: event.isError,
@@ -209,14 +188,12 @@ export const fromPiAgentSessionEvent = (
     case "compaction_start":
       return {
         type: "compaction_start",
-        correlation_id: correlationId,
         reason: event.reason,
       };
 
     case "compaction_end":
       return {
         type: "compaction_end",
-        correlation_id: correlationId,
         reason: event.reason,
         result:
           event.result !== undefined
@@ -233,7 +210,6 @@ export const fromPiAgentSessionEvent = (
     case "auto_retry_start":
       return {
         type: "auto_retry_start",
-        correlation_id: correlationId,
         attempt: event.attempt,
         maxAttempts: event.maxAttempts,
         delayMs: event.delayMs,
@@ -243,7 +219,6 @@ export const fromPiAgentSessionEvent = (
     case "auto_retry_end":
       return {
         type: "auto_retry_end",
-        correlation_id: correlationId,
         success: event.success,
         finalError: event.finalError,
       };
@@ -263,7 +238,6 @@ export const fromPiAgentSessionEvent = (
       }
       return {
         type: "error",
-        correlation_id: correlationId,
         message: msg.errorMessage ?? msg.stopReason,
         code: msg.stopReason,
       };
@@ -282,20 +256,17 @@ type PiAssistantMessageEvent = Extract<
 
 const fromAssistantMessageEvent = (
   event: PiAssistantMessageEvent,
-  correlationId: number,
 ): AgentSessionEvent | undefined => {
   switch (event.type) {
     case "thinking_start":
       return {
         type: "thinking_start",
-        correlation_id: correlationId,
         contentIndex: event.contentIndex,
       };
 
     case "thinking_end":
       return {
         type: "thinking_end",
-        correlation_id: correlationId,
         contentIndex: event.contentIndex,
         content: event.content,
       };
@@ -303,14 +274,12 @@ const fromAssistantMessageEvent = (
     case "text_start":
       return {
         type: "text_start",
-        correlation_id: correlationId,
         contentIndex: event.contentIndex,
       };
 
     case "text_end":
       return {
         type: "text_end",
-        correlation_id: correlationId,
         contentIndex: event.contentIndex,
         content: event.content,
       };
@@ -318,14 +287,12 @@ const fromAssistantMessageEvent = (
     case "toolcall_start":
       return {
         type: "toolcall_start",
-        correlation_id: correlationId,
         contentIndex: event.contentIndex,
       };
 
     case "toolcall_end":
       return {
         type: "toolcall_end",
-        correlation_id: correlationId,
         contentIndex: event.contentIndex,
         tool_call_id: event.toolCall.id,
         name: event.toolCall.name,
@@ -335,7 +302,6 @@ const fromAssistantMessageEvent = (
     case "error":
       return {
         type: "error",
-        correlation_id: correlationId,
         message: event.reason,
         code: event.reason,
       };

--- a/src/lib/event.test.ts
+++ b/src/lib/event.test.ts
@@ -7,6 +7,7 @@ const makeEvent = (type: string): Event => ({
   timestamp: 0,
   type,
   agent_id: "test",
+  depth: 0,
   payload: {},
 });
 

--- a/src/lib/event.ts
+++ b/src/lib/event.ts
@@ -3,6 +3,9 @@ export type Event = {
   timestamp: number;
   type: string;
   agent_id: string;
+  correlation_id?: number;
+  causation_id?: number;
+  depth: number;
   payload: unknown;
 };
 
@@ -16,6 +19,9 @@ export type RawEventRow = {
   timestamp: number;
   type: string;
   agent_id: string;
+  correlation_id: number | null;
+  causation_id: number | null;
+  depth: number;
   payload: string;
 };
 

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -179,6 +179,26 @@ describe("SDK clientOf", () => {
     assert.doesNotThrow(() => throwIfOrphaned(100, () => 100));
   });
 
+  it("publish threads cause through to correlation_id, causation_id, depth", () => {
+    const dbPath = createTempDbPath();
+    const client = clientOf({ id: "agent-a", dbPath });
+
+    const root = client.publish("flow.start", {});
+    assert.equal(root.depth, 0);
+    assert.equal(root.correlation_id, undefined);
+    assert.equal(root.causation_id, undefined);
+
+    const child = client.publish("flow.step", { n: 1 }, root);
+    assert.equal(child.causation_id, root.id);
+    assert.equal(child.correlation_id, root.id);
+    assert.equal(child.depth, 1);
+
+    const grandchild = client.publish("flow.step", { n: 2 }, child);
+    assert.equal(grandchild.causation_id, child.id);
+    assert.equal(grandchild.correlation_id, root.id);
+    assert.equal(grandchild.depth, 2);
+  });
+
   it("cursor advances across subscribe iterables", async () => {
     const dbPath = createTempDbPath();
     const producer = clientOf({ id: "producer", dbPath });

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -55,8 +55,12 @@ export type ListenConfig = {
 
 /** The client returned by `clientOf()`. */
 export type EventClient = {
-  /** Push an event to the queue. */
-  publish: (type: string, payload?: unknown) => Event;
+  /**
+   * Push an event to the queue. If `cause` is provided, the new event
+   * inherits its `correlation_id` (or the cause's own id if it's a root)
+   * and sets `causation_id` to `cause.id`, with `depth = cause.depth + 1`.
+   */
+  publish: (type: string, payload?: unknown, cause?: Event) => Event;
   /** Claim exclusive ownership of an event. Returns true if claimed. */
   claim: (eventId: number) => boolean;
   /** Async iterable that polls for matching events. Advances cursor after each yield. */
@@ -104,8 +108,8 @@ export const clientOf = ({
     }
   }
 
-  const publish = (type: string, payload: unknown = {}): Event =>
-    pushEvent(db, id, type, payload);
+  const publish = (type: string, payload: unknown = {}, cause?: Event): Event =>
+    pushEvent(db, id, type, payload, cause);
 
   const claim = (eventId: number): boolean => claimEvent(db, id, eventId);
 


### PR DESCRIPTION
These are two IDs commonly attached to messages/events to trace how they relate to one another across a distributed system.

**`correlation_id`**
- Identifies a whole logical flow or "conversation" — a request and everything it kicks off.
- Stays the same across every event in that flow, no matter how many hops or fan-outs.
- Used to answer: *"show me everything that happened as part of this user action / job / saga."*
- Typically set at the entry point (e.g., when an HTTP request arrives or a user submits a command) and propagated through every downstream event.

**`causation_id`**
- Identifies the *immediate* parent — the specific event or command that directly caused this one.
- Forms a parent→child chain, so you can reconstruct the causal tree.
- Used to answer: *"what triggered this event?"* and *"what did this event trigger in turn?"*

**The relationship**

```
Command A (id=1)
  correlation_id = 1
  causation_id   = 1   ← itself; it's the root

  → emits Event B (id=2)
       correlation_id = 1   ← same flow
       causation_id   = 1   ← caused by A

  → emits Event C (id=3)
       correlation_id = 1   ← same flow
       causation_id   = 2   ← caused by B, not A
```

So `correlation_id` flattens the whole flow into one bucket; `causation_id` preserves the tree structure inside that bucket.

**Why both**
- Correlation alone: you know events belong together, but lose ordering/causality.
- Causation alone: you can walk parent→child, but querying "everything for request X" requires recursive traversal.

Greg Young's writing on CQRS/Event Sourcing is the canonical reference.