### PR TITLE
Rename user/agent-facing "push" to "publish"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ _A town full of busy little guys who do things_
 
 **busytown** is a multi-agent factory built around a SQLite event queue. It can be used standalone, or as a [Pi](https://github.com/nichochar/pi-coding-agent) extension.
 
-Agents listen for events, react to them, and push new events, forming asynchronous assembly lines. Agents don't need to know about other agents, just about events.
+Agents listen for events, react to them, and publish new events, forming asynchronous assembly lines. Agents don't need to know about other agents, just about events.
 
 <p><img src="./busytown.png" src="A town full of busy little guys who do things" /></p>
 
@@ -29,17 +29,17 @@ in order. Each agent:
 
 - **Listens** for specific event types (exact match or glob like `task.*`)
 - **Reacts** by reading files, writing code, producing artifacts
-- **Pushes** new events to notify other agents of what it did
+- **Publishes** new events to notify other agents of what it did
 - **Claims** events when needed, so only one agent acts on a given event
 
 ## Architecture
 
 ```
-┌──────────┐    push     ┌─────────────────┐    dispatch    ┌───────────┐
+┌──────────┐   publish   ┌─────────────────┐    dispatch    ┌───────────┐
 │  Pi /    │───────────▸ │  SQLite Event   │ ─────────────▸ │  Agent    │
 │  CLI     │             │  Queue          │ ◂───────────── └───────────┘
-└──────────┘             │                 │    push new
-                         │  events table   │    events
+└──────────┘             │                 │   publish new
+                         │  events table   │   events
                          │  agent_cursors  │
                          │  claims         │
                          └─────────────────┘
@@ -102,7 +102,7 @@ pi
 Ask the agent to fire off an event:
 
 ```
-Push a "plan.request" message with payload '{"prd_path": "docs/add-auth.md"}'
+Publish a "plan.request" message with payload '{"prd_path": "docs/add-auth.md"}'
 ```
 
 This triggers the ralph loop: plan → code → review → plan... repeat until approved.
@@ -124,7 +124,7 @@ tools:
 When you receive a `task.created` event, read the file at
 `payload.file_path` and summarize it to `summaries/<name>.md`.
 
-Then push a `task.summarized` event.
+Then publish a `task.summarized` event.
 ```
 
 ### Frontmatter fields
@@ -272,23 +272,23 @@ Block values are stored separately at `.pi/busytown/memory_blocks/<agent_id>/<bl
 
 Busytown registers several additional tools for agents:
 
-| Tool              | Description                         |
-| ----------------- | ----------------------------------- |
-| `busytown-push`   | Push an event to the queue          |
-| `busytown-events` | List recent events (with filtering) |
-| `busytown-claim`  | Claim an event for exclusive access |
+| Tool               | Description                         |
+| ------------------ | ----------------------------------- |
+| `busytown-publish` | Publish an event to the queue       |
+| `busytown-events`  | List recent events (with filtering) |
+| `busytown-claim`   | Claim an event for exclusive access |
 
 You can manually call these tools, plus a few additional commands, from the Pi console.
 
-| Command             | Detail                                                          |
-| ------------------- | --------------------------------------------------------------- |
-| `/busytown-push`    | `/busytown-push plan.request '{"prd_path": "docs/feature.md"}'` |
-| `/busytown-events`  | `/busytown-events --tail 10 --type plan.*`                      |
-| `/busytown-claim`   | `/busytown-claim 42 my-agent`                                   |
-| `/busytown-console` | Display the event console                                       |
-| `/busytown-start`   | Start the daemon (run automatically when Pi starts)             |
-| `/busytown-stop`    | Stop the daemon                                                 |
-| `/busytown-reload`  | Reload agent definitions (sends `sys.reload` event)             |
+| Command             | Detail                                                             |
+| ------------------- | ------------------------------------------------------------------ |
+| `/busytown-publish` | `/busytown-publish plan.request '{"prd_path": "docs/feature.md"}'` |
+| `/busytown-events`  | `/busytown-events --tail 10 --type plan.*`                         |
+| `/busytown-claim`   | `/busytown-claim 42 my-agent`                                      |
+| `/busytown-console` | Display the event console                                          |
+| `/busytown-start`   | Start the daemon (run automatically when Pi starts)                |
+| `/busytown-stop`    | Stop the daemon                                                    |
+| `/busytown-reload`  | Reload agent definitions (sends `sys.reload` event)                |
 
 ## Interactive agent mode
 
@@ -326,8 +326,8 @@ Busytown also includes a standalone CLI. This lets you drive Busytown outside of
 # Start the agent system (daemon)
 busytown start
 
-# Push an event
-busytown push --agent my-script --type plan.request --payload '{"key":"value"}'
+# Publish an event
+busytown publish --agent my-script --type plan.request --payload '{"key":"value"}'
 
 # List events
 busytown events --tail 10 --type plan.*

--- a/src/agents/pi-agent-shared.ts
+++ b/src/agents/pi-agent-shared.ts
@@ -78,17 +78,17 @@ export const buildAgentAppendPrompt = (agent: AgentDef): string => {
   ].join("\n");
 };
 
-/** Register the three busytown queue tools (push, events, claim). */
+/** Register the three busytown queue tools (publish, events, claim). */
 export const registerBusytownTools = (
   pi: ExtensionAPI,
   db: DatabaseSync,
   defaultAgentId: string,
 ): void => {
   pi.registerTool({
-    name: "busytown-push",
-    label: "Busytown Push",
+    name: "busytown-publish",
+    label: "Busytown Publish",
     description:
-      "Push an event to the Busytown event queue to trigger agent workflows. " +
+      "Publish an event to the Busytown event queue to trigger agent workflows. " +
       "Common event types: plan.request, code.request, review.request",
     parameters: Type.Object({
       type: Type.String({ description: "Event type (e.g. 'plan.request')" }),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -321,8 +321,8 @@ const readPayload = (args: { payload?: string; msg?: string }) => {
   return {};
 };
 
-const pushCommand = defineCommand({
-  meta: { name: "push", description: "Push an event to the queue" },
+const publishCommand = defineCommand({
+  meta: { name: "publish", description: "Publish an event to the queue" },
   args: {
     ...globalArgs,
     agent: {
@@ -543,7 +543,7 @@ const main = defineCommand({
     stop: stopCommand,
     status: statusCommand,
     stats: statsCommand,
-    push: pushCommand,
+    publish: publishCommand,
     events: eventsCommand,
     claim: claimCommand,
     "check-claim": checkClaimCommand,

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,9 +104,9 @@ export default (pi: ExtensionAPI) => {
 
     // Register commands (slash-command equivalents of the tools)
 
-    pi.registerCommand("busytown-push", {
+    pi.registerCommand("busytown-publish", {
       description:
-        "Push an event to the Busytown event queue. Usage: /busytown-push <type> [payload-json] [--agent name]",
+        "Publish an event to the Busytown event queue. Usage: /busytown-publish <type> [payload-json] [--agent name]",
       handler: async (raw, ctx) => {
         await nextTick();
         const args = parseArgs(shellSplit(raw ?? ""), {
@@ -129,7 +129,7 @@ export default (pi: ExtensionAPI) => {
         });
         if (!args.type) {
           ctx.ui.notify(
-            "Usage: /busytown-push <type> [--agent name] [payload-json]",
+            "Usage: /busytown-publish <type> [--agent name] [payload-json]",
             "warning",
           );
           return;
@@ -137,7 +137,7 @@ export default (pi: ExtensionAPI) => {
         try {
           const payload = JSON.parse(args.payload);
           const event = pushEvent(db, args.agent, args.type, payload);
-          ctx.ui.notify(`Pushed event #${event.id} (${event.type})`, "info");
+          ctx.ui.notify(`Published event #${event.id} (${event.type})`, "info");
         } catch (err) {
           ctx.ui.notify(`Invalid payload JSON: ${err}`, "error");
         }


### PR DESCRIPTION
The high-level SDK already exposes `client.publish()` / `client.subscribe()`, but
the CLI subcommand, pi slash command, and pi tool were still named `push` — the
lower-level term that describes the SQLite insert mechanic. Publish/subscribe is
friendlier for humans and LLMs reading tool descriptions, so this renames the
user-facing surface to match the SDK.

## What changed

User-facing rename `push` → `publish`:

- **CLI**: `busytown push` → `busytown publish`
- **Pi slash command**: `/busytown-push` → `/busytown-publish`
- **Pi tool**: `busytown-push` → `busytown-publish` (tool name + label + description)
- **README**: prose, architecture diagram, examples, and tool/command tables

## What did NOT change

The underlying `pushEvent()` and `pullNextMatchingEvent()` functions in
`src/event-queue.ts` keep their names — they describe the DB-level mechanics
(insert into / scan from the queue), and that's the right level of meaning for
implementation code. The SDK's `publish` / `subscribe` already wrap them.

## Compatibility

Clean break, no aliases. Anyone with scripts that shell out to `busytown push`
or saved agent prompts referencing `busytown-push` will need to update to
`publish`.

## Test plan

- [x] `npm run check` — clean
- [x] `npm test` — 293/293 pass
- [ ] Smoke test the CLI: `busytown publish --agent test --type test.event --msg hi` emits an event
- [ ] Smoke test the pi command: `/busytown-publish test.event '{}'` notifies "Published event #N"
- [ ] Smoke test the pi tool: agent calling `busytown-publish` succeeds