### PR TITLE
Auto-claim option for subscriptions

### DIFF
--- a/src/agents/file-agent-loader.test.ts
+++ b/src/agents/file-agent-loader.test.ts
@@ -117,6 +117,36 @@ listen: []
     assert.equal(agent.ignoreSelf, true);
   });
 
+  it("defaults claim to false", () => {
+    const filePath = writeAgent(
+      "default.md",
+      `---
+listen: []
+---
+`,
+    );
+
+    const agent = loadAgentDef(filePath, { cwd: tmpDir });
+    assert.equal(agent.claim, false);
+  });
+
+  it("parses claim: true from frontmatter", () => {
+    const filePath = writeAgent(
+      "worker.md",
+      `---
+type: shell
+listen:
+  - work.do
+claim: true
+---
+echo handling {{event.id}}
+`,
+    );
+
+    const agent = loadAgentDef(filePath, { cwd: tmpDir });
+    assert.equal(agent.claim, true);
+  });
+
   it("handles tools as array", () => {
     const filePath = writeAgent(
       "tools-array.md",

--- a/src/agents/file-agent-loader.ts
+++ b/src/agents/file-agent-loader.ts
@@ -57,6 +57,7 @@ export const AgentFrontmatterSchema = Type.Object(
     description: Type.String({ default: "" }),
     listen: Type.Array(Type.String(), { default: [] }),
     ignore_self: Type.Boolean({ default: true }),
+    claim: Type.Boolean({ default: false }),
     emits: Type.Array(Type.String(), { default: [] }),
     tools: Type.Array(Type.String(), { default: [] }),
     model: Type.Optional(Type.String()),
@@ -109,6 +110,7 @@ export type PiAgentDef = {
   description: string;
   listen: string[];
   ignoreSelf: boolean;
+  claim: boolean;
   emits: string[];
   tools: string[];
   body: string;
@@ -125,6 +127,7 @@ export type PiRpcAgentDef = {
   description: string;
   listen: string[];
   ignoreSelf: boolean;
+  claim: boolean;
   emits: string[];
   tools: string[];
   body: string;
@@ -141,6 +144,7 @@ export type ShellAgentDef = {
   description: string;
   listen: string[];
   ignoreSelf: boolean;
+  claim: boolean;
   emits: string[];
   body: string;
   memoryBlocks: Record<string, MemoryBlockDef>;
@@ -153,6 +157,7 @@ export type ClaudeAgentDef = {
   description: string;
   listen: string[];
   ignoreSelf: boolean;
+  claim: boolean;
   emits: string[];
   tools: string[];
   body: string;
@@ -193,6 +198,7 @@ export const loadAgentDef = (
       description: fm.description,
       listen: fm.listen,
       ignoreSelf: fm.ignore_self,
+      claim: fm.claim,
       emits: fm.emits,
       body: content,
       memoryBlocks,
@@ -207,6 +213,7 @@ export const loadAgentDef = (
       description: fm.description,
       listen: fm.listen,
       ignoreSelf: fm.ignore_self,
+      claim: fm.claim,
       emits: fm.emits,
       tools: fm.tools,
       body: content.trim(),
@@ -223,6 +230,7 @@ export const loadAgentDef = (
       description: fm.description,
       listen: fm.listen,
       ignoreSelf: fm.ignore_self,
+      claim: fm.claim,
       emits: fm.emits,
       tools: fm.tools,
       body: content.trim(),
@@ -240,6 +248,7 @@ export const loadAgentDef = (
     description: fm.description,
     listen: fm.listen,
     ignoreSelf: fm.ignore_self,
+    claim: fm.claim,
     emits: fm.emits,
     tools: fm.tools,
     body: content.trim(),

--- a/src/agents/pi-agent-shared.test.ts
+++ b/src/agents/pi-agent-shared.test.ts
@@ -11,6 +11,7 @@ describe("buildAgentAppendPrompt", () => {
     description: "A test agent",
     listen: [],
     ignoreSelf: true,
+    claim: false,
     emits: [],
     tools: [],
     body: "You do test things.",

--- a/src/agents/pi-agent.ts
+++ b/src/agents/pi-agent.ts
@@ -58,6 +58,7 @@ export const piAgentHandler = async (
     id,
     listen,
     ignoreSelf,
+    claim,
     pollInterval,
     signal = neverAbortSignal,
     cwd = process.cwd(),
@@ -73,6 +74,7 @@ export const piAgentHandler = async (
   for await (const event of client.subscribe({
     listen,
     ignoreSelf,
+    claim,
     pollInterval,
     signal,
   })) {

--- a/src/agents/pi-rpc-agent.ts
+++ b/src/agents/pi-rpc-agent.ts
@@ -58,6 +58,7 @@ export const piRpcAgentHandler = async (
     id,
     listen,
     ignoreSelf,
+    claim,
     pollInterval,
     signal = neverAbortSignal,
     cwd = process.cwd(),
@@ -131,6 +132,7 @@ export const piRpcAgentHandler = async (
   for await (const event of client.subscribe({
     listen: fullListen,
     ignoreSelf,
+    claim,
     pollInterval,
     signal: loopAbortSignal,
   })) {

--- a/src/agents/shell-agent.test.ts
+++ b/src/agents/shell-agent.test.ts
@@ -24,6 +24,7 @@ const handlerConfig = (
   description: "test",
   listen: ["test.*"],
   ignoreSelf: true,
+  claim: false,
   emits: [],
   body,
   memoryBlocks: {},

--- a/src/agents/shell-agent.ts
+++ b/src/agents/shell-agent.ts
@@ -20,6 +20,7 @@ export const shellAgentHandler = async (
     env = {},
     listen,
     ignoreSelf,
+    claim,
     pollInterval,
     signal,
   } = config;
@@ -27,6 +28,7 @@ export const shellAgentHandler = async (
   for await (const event of client.subscribe({
     listen,
     ignoreSelf,
+    claim,
     pollInterval,
     signal,
   })) {

--- a/src/event-queue.test.ts
+++ b/src/event-queue.test.ts
@@ -352,6 +352,142 @@ describe("pullNextMatchingEvent", () => {
   });
 });
 
+describe("pullNextMatchingEvent with claim: true", () => {
+  const initPuller = (db: DatabaseSync, id: string): void => {
+    getOrCreateCursor(db, id);
+  };
+
+  it("claims the matched event and yields it", () => {
+    const db = createTestDb();
+    initPuller(db, "puller");
+    const e1 = pushEvent(db, "w", "task");
+
+    const result = pullNextMatchingEvent(
+      db,
+      "puller",
+      (e) => e.type === "task",
+      true,
+    );
+
+    assert.equal(result?.id, e1.id);
+    assert.equal(getClaimant(db, e1.id)?.agent_id, "puller");
+    assert.equal(getCursor(db, "puller"), e1.id);
+    db.close();
+  });
+
+  it("publishes a sys.claim.create event attributed to the claimer", () => {
+    const db = createTestDb();
+    initPuller(db, "puller");
+    const e1 = pushEvent(db, "w", "task");
+
+    pullNextMatchingEvent(db, "puller", (e) => e.type === "task", true);
+
+    const claimEvents = getEventsSince(db, {
+      sinceId: 0,
+      filterType: "sys.claim.create",
+    });
+    assert.equal(claimEvents.length, 1);
+    assert.equal(claimEvents[0].agent_id, "puller");
+    assert.deepEqual(claimEvents[0].payload, { event_id: e1.id });
+    db.close();
+  });
+
+  it("first caller wins; second caller skips and gets undefined", () => {
+    const db = createTestDb();
+    initPuller(db, "agent-a");
+    initPuller(db, "agent-b");
+    const e1 = pushEvent(db, "w", "task");
+
+    const resultA = pullNextMatchingEvent(
+      db,
+      "agent-a",
+      (e) => e.type === "task",
+      true,
+    );
+    const resultB = pullNextMatchingEvent(
+      db,
+      "agent-b",
+      (e) => e.type === "task",
+      true,
+    );
+
+    assert.equal(resultA?.id, e1.id);
+    assert.equal(resultB, undefined);
+    assert.equal(getClaimant(db, e1.id)?.agent_id, "agent-a");
+    // Both cursors advanced past the event so neither will retry it.
+    assert.ok(getCursor(db, "agent-a") >= e1.id);
+    assert.ok(getCursor(db, "agent-b") >= e1.id);
+    db.close();
+  });
+
+  it("skips events already claimed by another agent", () => {
+    const db = createTestDb();
+    initPuller(db, "puller");
+    const e1 = pushEvent(db, "w", "task");
+    const e2 = pushEvent(db, "w", "task");
+
+    claimEvent(db, "other-agent", e1.id);
+
+    const result = pullNextMatchingEvent(
+      db,
+      "puller",
+      (e) => e.type === "task",
+      true,
+    );
+
+    assert.equal(result?.id, e2.id);
+    assert.equal(getClaimant(db, e1.id)?.agent_id, "other-agent");
+    assert.equal(getClaimant(db, e2.id)?.agent_id, "puller");
+    db.close();
+  });
+
+  it("returns undefined when no events match filter, advances cursor", () => {
+    const db = createTestDb();
+    initPuller(db, "puller");
+    pushEvent(db, "w", "a");
+    const last = pushEvent(db, "w", "a");
+
+    const result = pullNextMatchingEvent(
+      db,
+      "puller",
+      (e) => e.type === "z",
+      true,
+    );
+
+    assert.equal(result, undefined);
+    assert.equal(getCursor(db, "puller"), last.id);
+    db.close();
+  });
+
+  it("returns undefined when queue is empty", () => {
+    const db = createTestDb();
+    const result = pullNextMatchingEvent(db, "puller", () => true, true);
+    assert.equal(result, undefined);
+    db.close();
+  });
+
+  it("walks past non-matching and other-claimed events to find a free match", () => {
+    const db = createTestDb();
+    initPuller(db, "puller");
+    pushEvent(db, "w", "skip"); // filter miss
+    const claimedByOther = pushEvent(db, "w", "task");
+    const free = pushEvent(db, "w", "task");
+
+    claimEvent(db, "other", claimedByOther.id);
+
+    const result = pullNextMatchingEvent(
+      db,
+      "puller",
+      (e) => e.type === "task",
+      true,
+    );
+
+    assert.equal(result?.id, free.id);
+    assert.equal(getClaimant(db, free.id)?.agent_id, "puller");
+    db.close();
+  });
+});
+
 describe("pollEvents", () => {
   it("returns new events and advances cursor", () => {
     const db = createTestDb();

--- a/src/event-queue.test.ts
+++ b/src/event-queue.test.ts
@@ -551,6 +551,22 @@ describe("claimEvent / getClaimant", () => {
     db.close();
   });
 
+  it("emits sys.claim.create exactly once across repeated re-claims", () => {
+    const db = createTestDb();
+    const event = pushEvent(db, "w", "task");
+
+    claimEvent(db, "claimer", event.id);
+    claimEvent(db, "claimer", event.id);
+    claimEvent(db, "claimer", event.id);
+
+    const claimEvents = getEventsSince(db, {
+      sinceId: 0,
+      filterType: "sys.claim.create",
+    });
+    assert.equal(claimEvents.length, 1);
+    db.close();
+  });
+
   it("getClaimant returns claimant info", () => {
     const db = createTestDb();
     const event = pushEvent(db, "w", "task");

--- a/src/event-queue.ts
+++ b/src/event-queue.ts
@@ -228,46 +228,64 @@ export const getEventById = (
   return row ? parseEvent(row) : undefined;
 };
 
-export const pullNextMatchingEvent = (
+const _pullNextMatchingEvent = (
   db: DatabaseSync,
   id: string,
   filter: (event: Event) => boolean,
-  claim: boolean = false,
-  maxScan: number = 100,
+  maxScan: number,
 ): Event | undefined => {
   const sinceId = getOrCreateCursor(db, id);
   const events = getNextEvents(db, sinceId, maxScan);
-  if (events.length === 0) {
-    return undefined;
-  }
+  if (events.length === 0) return undefined;
 
-  if (!claim) {
-    for (const event of events) {
-      if (filter(event) && !isClaimed(db, event.id)) {
-        updateCursor(db, id, event.id);
-        return event;
-      }
+  for (const event of events) {
+    if (filter(event) && !isClaimed(db, event.id)) {
+      updateCursor(db, id, event.id);
+      return event;
     }
-    updateCursor(db, id, events[events.length - 1].id);
-    return undefined;
   }
+  updateCursor(db, id, events[events.length - 1].id);
+  return undefined;
+};
 
-  // claim: true — wrap the claim insert + sys.claim.create publish + cursor
-  // advance in one transaction so a race-loser doesn't leak partial state.
+/**
+ * Insert a claim row and emit sys.claim.create on success. Caller owns the
+ * transaction. Returns true if this caller just won the insert; false if the
+ * insert was a no-op (event already claimed by this agent or someone else).
+ */
+const _claimEvent = (
+  db: DatabaseSync,
+  agentId: string,
+  eventId: number,
+  cause?: Event,
+): boolean => {
+  const changes = db
+    .prepare(`INSERT OR IGNORE INTO claims (event_id, agent_id) VALUES (?, ?)`)
+    .run(eventId, agentId).changes as number;
+  if (changes === 0) return false;
+  pushEvent(db, agentId, "sys.claim.create", { event_id: eventId }, cause);
+  return true;
+};
+
+const _pullAndClaimNextMatchingEvent = (
+  db: DatabaseSync,
+  id: string,
+  filter: (event: Event) => boolean,
+  maxScan: number,
+  cause?: Event,
+): Event | undefined => {
+  const sinceId = getOrCreateCursor(db, id);
+  const events = getNextEvents(db, sinceId, maxScan);
+  if (events.length === 0) return undefined;
+
+  // Claim insert + sys.claim.create publish + cursor advance must be atomic
+  // so a race-loser doesn't leak partial state.
   db.exec("BEGIN");
   try {
     for (const event of events) {
       if (!filter(event)) continue;
-      const changes = db
-        .prepare(
-          `INSERT OR IGNORE INTO claims (event_id, agent_id) VALUES (?, ?)`,
-        )
-        .run(event.id, id).changes as number;
-      // Lost the race (or already claimed). Don't advance cursor here — the
-      // final updateCursor below will skip past this and any later losers,
-      // since they belong to whichever agent did claim them.
-      if (changes === 0) continue;
-      pushEvent(db, id, "sys.claim.create", { event_id: event.id }, event);
+      // Race-loser (or already claimed): final updateCursor below skips past.
+      if (!_claimEvent(db, id, event.id, cause)) continue;
       updateCursor(db, id, event.id);
       db.exec("COMMIT");
       return event;
@@ -280,6 +298,18 @@ export const pullNextMatchingEvent = (
     throw err;
   }
 };
+
+export const pullNextMatchingEvent = (
+  db: DatabaseSync,
+  id: string,
+  filter: (event: Event) => boolean,
+  claim: boolean = false,
+  maxScan: number = 100,
+  cause?: Event,
+): Event | undefined =>
+  claim
+    ? _pullAndClaimNextMatchingEvent(db, id, filter, maxScan, cause)
+    : _pullNextMatchingEvent(db, id, filter, maxScan);
 
 export const pollEvents = (
   db: DatabaseSync,
@@ -299,25 +329,21 @@ export const claimEvent = (
   db: DatabaseSync,
   agentId: string,
   eventId: number,
+  cause?: Event,
 ): boolean => {
   db.exec("BEGIN");
   try {
-    db.prepare(
-      `INSERT OR IGNORE INTO claims (event_id, agent_id) VALUES (?, ?)`,
-    ).run(eventId, agentId);
-
-    const row = db
-      .prepare(`SELECT agent_id FROM claims WHERE event_id = ?`)
-      .get(eventId) as { agent_id: string } | undefined;
-
-    if (row?.agent_id === agentId) {
-      const target = getEventById(db, eventId);
-      pushEvent(db, agentId, "sys.claim.create", { event_id: eventId }, target);
+    if (_claimEvent(db, agentId, eventId, cause)) {
       db.exec("COMMIT");
       return true;
     }
+    // Insert was a no-op. Idempotent re-claim: return true if this agent
+    // already owns the claim, without re-emitting sys.claim.create.
+    const row = db
+      .prepare(`SELECT agent_id FROM claims WHERE event_id = ?`)
+      .get(eventId) as { agent_id: string } | undefined;
     db.exec("COMMIT");
-    return false;
+    return row?.agent_id === agentId;
   } catch (err) {
     db.exec("ROLLBACK");
     throw err;

--- a/src/event-queue.ts
+++ b/src/event-queue.ts
@@ -257,13 +257,12 @@ const _claimEvent = (
   db: DatabaseSync,
   agentId: string,
   eventId: number,
-  cause?: Event,
 ): boolean => {
   const changes = db
     .prepare(`INSERT OR IGNORE INTO claims (event_id, agent_id) VALUES (?, ?)`)
     .run(eventId, agentId).changes as number;
   if (changes === 0) return false;
-  pushEvent(db, agentId, "sys.claim.create", { event_id: eventId }, cause);
+  pushEvent(db, agentId, "sys.claim.create", { event_id: eventId });
   return true;
 };
 
@@ -272,7 +271,6 @@ const _pullAndClaimNextMatchingEvent = (
   id: string,
   filter: (event: Event) => boolean,
   maxScan: number,
-  cause?: Event,
 ): Event | undefined => {
   const sinceId = getOrCreateCursor(db, id);
   const events = getNextEvents(db, sinceId, maxScan);
@@ -285,7 +283,7 @@ const _pullAndClaimNextMatchingEvent = (
     for (const event of events) {
       if (!filter(event)) continue;
       // Race-loser (or already claimed): final updateCursor below skips past.
-      if (!_claimEvent(db, id, event.id, cause)) continue;
+      if (!_claimEvent(db, id, event.id)) continue;
       updateCursor(db, id, event.id);
       db.exec("COMMIT");
       return event;
@@ -305,10 +303,9 @@ export const pullNextMatchingEvent = (
   filter: (event: Event) => boolean,
   claim: boolean = false,
   maxScan: number = 100,
-  cause?: Event,
 ): Event | undefined =>
   claim
-    ? _pullAndClaimNextMatchingEvent(db, id, filter, maxScan, cause)
+    ? _pullAndClaimNextMatchingEvent(db, id, filter, maxScan)
     : _pullNextMatchingEvent(db, id, filter, maxScan);
 
 export const pollEvents = (
@@ -329,11 +326,10 @@ export const claimEvent = (
   db: DatabaseSync,
   agentId: string,
   eventId: number,
-  cause?: Event,
 ): boolean => {
   db.exec("BEGIN");
   try {
-    if (_claimEvent(db, agentId, eventId, cause)) {
+    if (_claimEvent(db, agentId, eventId)) {
       db.exec("COMMIT");
       return true;
     }

--- a/src/event-queue.ts
+++ b/src/event-queue.ts
@@ -232,6 +232,7 @@ export const pullNextMatchingEvent = (
   db: DatabaseSync,
   id: string,
   filter: (event: Event) => boolean,
+  claim: boolean = false,
   maxScan: number = 100,
 ): Event | undefined => {
   const sinceId = getOrCreateCursor(db, id);
@@ -240,17 +241,44 @@ export const pullNextMatchingEvent = (
     return undefined;
   }
 
-  for (const event of events) {
-    if (filter(event) && !isClaimed(db, event.id)) {
-      // Advance cursor to the matched event
-      updateCursor(db, id, event.id);
-      return event;
+  if (!claim) {
+    for (const event of events) {
+      if (filter(event) && !isClaimed(db, event.id)) {
+        updateCursor(db, id, event.id);
+        return event;
+      }
     }
+    updateCursor(db, id, events[events.length - 1].id);
+    return undefined;
   }
 
-  // No match — advance cursor past all scanned events
-  updateCursor(db, id, events[events.length - 1].id);
-  return undefined;
+  // claim: true — wrap the claim insert + sys.claim.create publish + cursor
+  // advance in one transaction so a race-loser doesn't leak partial state.
+  db.exec("BEGIN");
+  try {
+    for (const event of events) {
+      if (!filter(event)) continue;
+      const changes = db
+        .prepare(
+          `INSERT OR IGNORE INTO claims (event_id, agent_id) VALUES (?, ?)`,
+        )
+        .run(event.id, id).changes as number;
+      // Lost the race (or already claimed). Don't advance cursor here — the
+      // final updateCursor below will skip past this and any later losers,
+      // since they belong to whichever agent did claim them.
+      if (changes === 0) continue;
+      pushEvent(db, id, "sys.claim.create", { event_id: event.id }, event);
+      updateCursor(db, id, event.id);
+      db.exec("COMMIT");
+      return event;
+    }
+    updateCursor(db, id, events[events.length - 1].id);
+    db.exec("COMMIT");
+    return undefined;
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  }
 };
 
 export const pollEvents = (
@@ -283,7 +311,8 @@ export const claimEvent = (
       .get(eventId) as { agent_id: string } | undefined;
 
     if (row?.agent_id === agentId) {
-      pushEvent(db, agentId, "sys.claim.create", { event_id: eventId });
+      const target = getEventById(db, eventId);
+      pushEvent(db, agentId, "sys.claim.create", { event_id: eventId }, target);
       db.exec("COMMIT");
       return true;
     }

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -113,6 +113,129 @@ describe("SDK clientOf", () => {
     assert.equal(claimedB, false);
   });
 
+  it("subscribe without claim is multicast: two subscribers both see each event", async () => {
+    const dbPath = createTempDbPath();
+    const producer = clientOf({ id: "producer", dbPath });
+    const consumerA = clientOf({ id: "consumer-a", dbPath });
+    const consumerB = clientOf({ id: "consumer-b", dbPath });
+
+    const published = producer.publish("multicast.msg", { n: 1 });
+
+    const eventsA: { id: number }[] = [];
+    for await (const event of consumerA.subscribe({
+      listen: ["multicast.*"],
+      pollInterval: 10,
+    })) {
+      eventsA.push(event);
+      break;
+    }
+
+    const eventsB: { id: number }[] = [];
+    for await (const event of consumerB.subscribe({
+      listen: ["multicast.*"],
+      pollInterval: 10,
+    })) {
+      eventsB.push(event);
+      break;
+    }
+
+    assert.equal(eventsA[0].id, published.id);
+    assert.equal(eventsB[0].id, published.id);
+  });
+
+  it("subscribe with claim:true partitions events between competing consumers", async () => {
+    const dbPath = createTempDbPath();
+    const producer = clientOf({ id: "producer", dbPath });
+    const workerA = clientOf({ id: "worker-a", dbPath });
+    const workerB = clientOf({ id: "worker-b", dbPath });
+
+    const expectedCount = 3;
+    producer.publish("work.do", { n: 1 });
+    producer.publish("work.do", { n: 2 });
+    producer.publish("work.do", { n: 3 });
+
+    const aborter = new AbortController();
+    const idsA: number[] = [];
+    const idsB: number[] = [];
+
+    const checkDone = (): void => {
+      if (idsA.length + idsB.length >= expectedCount) aborter.abort();
+    };
+    // Safety net: if a regression makes one worker silently never yield,
+    // make the test fail fast instead of hanging until the runner timeout.
+    const safety = setTimeout(() => aborter.abort(), 1000);
+
+    const runA = (async () => {
+      for await (const event of workerA.subscribe({
+        listen: ["work.*"],
+        claim: true,
+        pollInterval: 5,
+        signal: aborter.signal,
+      })) {
+        idsA.push(event.id);
+        checkDone();
+      }
+    })();
+
+    const runB = (async () => {
+      for await (const event of workerB.subscribe({
+        listen: ["work.*"],
+        claim: true,
+        pollInterval: 5,
+        signal: aborter.signal,
+      })) {
+        idsB.push(event.id);
+        checkDone();
+      }
+    })();
+
+    await Promise.all([runA, runB]);
+    clearTimeout(safety);
+
+    const union = [...idsA, ...idsB].sort((a, b) => a - b);
+    const dedup = Array.from(new Set(union));
+    assert.equal(union.length, expectedCount, "no event consumed twice");
+    assert.equal(dedup.length, expectedCount, "no duplicate ids");
+  });
+
+  it("speculative claim() still works alongside a claim:true subscriber", async () => {
+    const dbPath = createTempDbPath();
+    const producer = clientOf({ id: "producer", dbPath });
+    const observer = clientOf({ id: "observer", dbPath });
+    const worker = clientOf({ id: "worker", dbPath });
+
+    const event = producer.publish("speculative.task", {});
+
+    // Observer pulls the event without claiming it.
+    let observed: { id: number } | undefined;
+    for await (const e of observer.subscribe({
+      listen: ["speculative.*"],
+      pollInterval: 5,
+    })) {
+      observed = e;
+      break;
+    }
+    assert.equal(observed?.id, event.id);
+
+    // Observer decides to take it via the explicit claim() call.
+    const observerWon = observer.claim(event.id);
+    assert.equal(observerWon, true);
+
+    // A later claim:true subscriber should not see the now-claimed event.
+    const aborter = new AbortController();
+    const workerEvents: { id: number }[] = [];
+    setTimeout(() => aborter.abort(), 50);
+    for await (const e of worker.subscribe({
+      listen: ["speculative.*"],
+      claim: true,
+      pollInterval: 5,
+      signal: aborter.signal,
+    })) {
+      workerEvents.push(e);
+    }
+    assert.equal(workerEvents.length, 0);
+  });
+
   it("subscribe throws when parentPid no longer matches process.ppid", async () => {
     const dbPath = createTempDbPath();
     const producer = clientOf({ id: "producer", dbPath });

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -68,7 +68,7 @@ export type EventClient = {
    */
   publish: (type: string, payload?: unknown, cause?: Event) => Event;
   /** Claim exclusive ownership of an event. Returns true if claimed. */
-  claim: (eventId: number, cause?: Event) => boolean;
+  claim: (eventId: number) => boolean;
   /** Async iterable that polls for matching events. Advances cursor after each yield. */
   subscribe: (config: ListenConfig) => AsyncIterable<Event>;
 };
@@ -107,7 +107,7 @@ export const clientOf = ({
     const shouldHandle = shouldHandleEventOf(id, ignoreSelf, listen);
     while (!signal.aborted) {
       if (parentPid !== undefined) throwIfOrphaned(parentPid);
-      const event = pullNextMatchingEvent(db, id, shouldHandle, claim);
+      const event = pullNextMatchingEvent(db, id, shouldHandle, claim, 100);
       if (event) {
         yield event;
       } else {
@@ -119,8 +119,7 @@ export const clientOf = ({
   const publish = (type: string, payload: unknown = {}, cause?: Event): Event =>
     pushEvent(db, id, type, payload, cause);
 
-  const claim = (eventId: number, cause?: Event): boolean =>
-    claimEvent(db, id, eventId, cause);
+  const claim = (eventId: number): boolean => claimEvent(db, id, eventId);
 
   return {
     publish,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -68,7 +68,7 @@ export type EventClient = {
    */
   publish: (type: string, payload?: unknown, cause?: Event) => Event;
   /** Claim exclusive ownership of an event. Returns true if claimed. */
-  claim: (eventId: number) => boolean;
+  claim: (eventId: number, cause?: Event) => boolean;
   /** Async iterable that polls for matching events. Advances cursor after each yield. */
   subscribe: (config: ListenConfig) => AsyncIterable<Event>;
 };
@@ -119,7 +119,8 @@ export const clientOf = ({
   const publish = (type: string, payload: unknown = {}, cause?: Event): Event =>
     pushEvent(db, id, type, payload, cause);
 
-  const claim = (eventId: number): boolean => claimEvent(db, id, eventId);
+  const claim = (eventId: number, cause?: Event): boolean =>
+    claimEvent(db, id, eventId, cause);
 
   return {
     publish,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -51,6 +51,12 @@ export type ListenConfig = {
   pollInterval?: number;
   /** Signal to stop the subscribe loop. */
   signal?: AbortSignal;
+  /**
+   * If true, atomically claim each event before yielding. Only events this
+   * agent successfully claims are yielded; events claimed by other agents are
+   * skipped (the cursor still advances past them). Default: false.
+   */
+  claim?: boolean;
 };
 
 /** The client returned by `clientOf()`. */
@@ -88,6 +94,7 @@ export const clientOf = ({
     ignoreSelf = true,
     pollInterval = 1000,
     signal = neverAbortSignal,
+    claim = false,
   }: ListenConfig): AsyncGenerator<Event> {
     clientLogger.debug(`subscribe`, {
       id,
@@ -95,11 +102,12 @@ export const clientOf = ({
       listen,
       ignoreSelf,
       pollInterval,
+      claim,
     });
     const shouldHandle = shouldHandleEventOf(id, ignoreSelf, listen);
     while (!signal.aborted) {
       if (parentPid !== undefined) throwIfOrphaned(parentPid);
-      const event = pullNextMatchingEvent(db, id, shouldHandle);
+      const event = pullNextMatchingEvent(db, id, shouldHandle, claim);
       if (event) {
         yield event;
       } else {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -107,7 +107,7 @@ export const clientOf = ({
     const shouldHandle = shouldHandleEventOf(id, ignoreSelf, listen);
     while (!signal.aborted) {
       if (parentPid !== undefined) throwIfOrphaned(parentPid);
-      const event = pullNextMatchingEvent(db, id, shouldHandle, claim, 100);
+      const event = pullNextMatchingEvent(db, id, shouldHandle, claim);
       if (event) {
         yield event;
       } else {


### PR DESCRIPTION
Add opt-in `claim` mode for competing-consumer subscriptions.

## Summary

- Add `claim` flag to subscribe that atomically claims events that match
- Add a `claim` field to `file-agent.ts` frontmatter that does the same

Default behavior is unchanged: subscriptions remain multicast unless an agent (or its frontmatter) opts in.

## Why

Today, every agent matching a `listen` pattern sees every event, and `claim()` is a separate post-hoc call. To build a worker pool that splits work across N agents, each agent has to re-implement "see → race to claim → handle if won" — including the small race window between `pullNextMatchingEvent` and `claim()` where two agents can both yield the same event. Pushing that coordination into the subscription is cleaner, atomic, and matches how every mature event/queue system exposes the choice.

## What changed

**Core: `pullNextMatchingEvent` now dispatches on a `claim: boolean` flag (`src/event-queue.ts`)**

- `_pullNextMatchingEvent` — multicast read, unchanged behavior. Skips already-claimed events; cursor advances past matched event or whole scanned batch on miss.
- `_pullAndClaimNextMatchingEvent` — wraps the scan loop in one `BEGIN`/`COMMIT`. For each candidate, atomically `INSERT OR IGNORE INTO claims`; on win, emit `sys.claim.create` and advance cursor; on race-loss, `continue` (the trailing `updateCursor` skips past lost-race events the same way it skips filter misses).
- `pullNextMatchingEvent` is now a thin dispatch over the two.
- The atomic primitive is factored into `_claimEvent` — a no-transaction helper that does the `INSERT OR IGNORE` + `sys.claim.create` publish, returning `true` only when the insert actually happened. Caller owns the transaction.

**Bug fix: `claimEvent` no longer emits duplicate `sys.claim.create` events on idempotent re-claims**

Previously, `claimEvent(agent, X)` called twice in a row would emit two `sys.claim.create` events. Now `claimEvent` calls `_claimEvent`; if the insert was a no-op, it does the existing post-`SELECT` to confirm ownership and returns `true` without re-publishing. Public return value unchanged.

**SDK: `claim?: boolean` on `ListenConfig` (`src/sdk.ts`)**

Defaults to `false` (multicast). When `true`, threaded straight into `pullNextMatchingEvent`.

**File-agent frontmatter: `claim` field on agent definitions (`src/agents/file-agent-loader.ts` + `shell-agent.ts`, `pi-agent.ts`, `pi-rpc-agent.ts`)**

```yaml
---
type: shell
listen:
  - work.do
claim: true
---
```

Defaults to `false`. All four `AgentDef` variants (pi, pi-rpc, shell, claude) carry the field for type symmetry; the three live handlers thread it into their `client.subscribe(...)` call.

## Design notes

- **Cursor under `claim: true`**: still advances past events claimed (or won) by *other* agents — they're not yours to see again.
- **Atomicity**: claim insert + `sys.claim.create` + cursor advance are one transaction so a race-loser doesn't leave behind a partial state (e.g., a claim row without a matching cursor advance, which would orphan the event).
- **`sys.claim.create` is causally a root event**: this might change if we set a root event during subscription poll.
- **Out of scope**: lease expiry / heartbeats for crashed claimers; per-event-type encoding of claim semantics. Easy to layer on later.

### Test plan

- [x] `npm run check` (tsc) — clean
- [x] `npm test` — 306 tests pass (was 293; +13 new)
- [x] Existing `pullNextMatchingEvent` and `claimEvent` tests unchanged and passing (regression guard)
- [x] New unit tests for `claim: true` covering: happy path, first-wins race, pre-claimed events, filter miss, empty queue, mixed batch
- [x] New unit test for the duplicate-emit bug fix
- [x] New SDK integration tests for: multicast default (assert same event id), competing-consumers partitioning (with timeout safety net), speculative `claim()` interaction
- [x] New loader tests: `claim` defaults to `false`, parses `true` from frontmatter
- [ ] Manual smoke: two `claim: true` shell agents on the same listen pattern should partition events, verifiable via `claims` table

### Commits

1. `5624233` Add `claim` flag to subscribe
2. `7ba7a2a` Add claim field to frontmatter for file-agent.ts
3. `0565120` Consolidate claim logic
4. `bfd9cc9` Claims don't have a cause
5. `32c9586` Remove maxScan